### PR TITLE
Batch insert av sykefravarsstatistikk virksomhet

### DIFF
--- a/dev-nais.yaml
+++ b/dev-nais.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: teamtag
 spec:
-  image: navikt/sykefravarsstatistikk-api:91789aa73e0cc2bc6ade62a38048bac97eb21ac3
+  image: navikt/sykefravarsstatistikk-api:{{version}}
   team: teamtag
   port: 8080
   ingresses:

--- a/dev-nais.yaml
+++ b/dev-nais.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: teamtag
 spec:
-  image: navikt/sykefravarsstatistikk-api:{{version}}
+  image: navikt/sykefravarsstatistikk-api:1b79c287a0673e2980146a1ffc657cbbe1f65102
   team: teamtag
   port: 8080
   ingresses:
@@ -28,6 +28,6 @@ spec:
     enabled: true
   resources:
     limits:
-      memory: 1024
+      memory: 1024Mi
     requests:
-      memory: 512
+      memory: 512Mi

--- a/dev-nais.yaml
+++ b/dev-nais.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: teamtag
 spec:
-  image: navikt/sykefravarsstatistikk-api:1b79c287a0673e2980146a1ffc657cbbe1f65102
+  image: navikt/sykefravarsstatistikk-api:{{version}}
   team: teamtag
   port: 8080
   ingresses:

--- a/dev-nais.yaml
+++ b/dev-nais.yaml
@@ -6,17 +6,17 @@ metadata:
   labels:
     team: teamtag
 spec:
-  image: navikt/sykefravarsstatistikk-api:{{version}}
+  image: navikt/sykefravarsstatistikk-api:91789aa73e0cc2bc6ade62a38048bac97eb21ac3
   team: teamtag
   port: 8080
   ingresses:
     - https://arbeidsgiver.nais.preprod.local/sykefravarsstatistikk-api/
   liveness:
     path: /sykefravarsstatistikk-api/internal/healthcheck
-    initialDelay: 20
+    initialDelay: 30
   readiness:
     path: /sykefravarsstatistikk-api/internal/healthcheck
-    initialDelay: 20
+    initialDelay: 30
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: dev

--- a/dev-nais.yaml
+++ b/dev-nais.yaml
@@ -26,3 +26,8 @@ spec:
   webproxy: true
   vault:
     enabled: true
+  resources:
+    limits:
+      memory: 1024
+    requests:
+      memory: 512

--- a/prod-nais.yaml
+++ b/prod-nais.yaml
@@ -13,10 +13,10 @@ spec:
     - https://arbeidsgiver.nais.adeo.no/sykefravarsstatistikk-api/
   liveness:
     path: /sykefravarsstatistikk-api/internal/healthcheck
-    initialDelay: 20
+    initialDelay: 30
   readiness:
     path: /sykefravarsstatistikk-api/internal/healthcheck
-    initialDelay: 20
+    initialDelay: 30
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod

--- a/prod-nais.yaml
+++ b/prod-nais.yaml
@@ -26,3 +26,8 @@ spec:
   webproxy: true
   vault:
     enabled: true
+  resources:
+    limits:
+      memory: 1024Mi
+    requests:
+      memory: 512Mi

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/DataverehusRepository.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/DataverehusRepository.java
@@ -136,6 +136,7 @@ public class DataverehusRepository {
                         "sum(muligedv) as sum_mulige_dagsverk " +
                         "from dt_p.v_agg_ia_sykefravar " +
                         "where kjonn != 'X' and naring != 'X' " +
+                        "and orgnr > '980000000' and orgnr <= '999999999' " +
                         "and arstall = :arstall and kvartal = :kvartal " +
                         "group by arstall, kvartal, orgnr",
                 namedParameters,

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/DataverehusRepository.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/DataverehusRepository.java
@@ -136,7 +136,6 @@ public class DataverehusRepository {
                         "sum(muligedv) as sum_mulige_dagsverk " +
                         "from dt_p.v_agg_ia_sykefravar " +
                         "where kjonn != 'X' and naring != 'X' " +
-                        "and orgnr > '980000000' and orgnr <= '999999999' " +
                         "and arstall = :arstall and kvartal = :kvartal " +
                         "group by arstall, kvartal, orgnr",
                 namedParameters,

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportController.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportController.java
@@ -24,26 +24,6 @@ public class StatistikkImportController {
         this.service = service;
     }
 
-    // TODO: DELETE ME! fjerne disse GET endepunkter som brukes til verifisering i dev miljø
-    @GetMapping(value = "/verif/datavarehus/sykefravar/land/{årstall}/{kvartal}")
-    public List<SykefraværsstatistikkLand> hentSykefraværsstatistikkLand(@PathVariable int årstall, @PathVariable int kvartal) {
-        return service.hentSykefraværsstatistikkLand(new ÅrstallOgKvartal(årstall, kvartal));
-    }
-
-    @GetMapping(value = "/verif/datavarehus/sykefravar/sektor/{årstall}/{kvartal}")
-    public List<SykefraværsstatistikkSektor> hentSykefraværsstatistikkSektor(@PathVariable int årstall, @PathVariable int kvartal) {
-        return service.hentSykefraværsstatistikkSektor(new ÅrstallOgKvartal(årstall, kvartal));
-    }
-
-    @GetMapping(value = "/verif/datavarehus/sykefravar/naring/{årstall}/{kvartal}")
-    public List<SykefraværsstatistikkNæring> hentSykefraværsstatistikkNæring(@PathVariable int årstall, @PathVariable int kvartal) {
-        return service.hentSykefraværsstatistikkNæring(new ÅrstallOgKvartal(årstall, kvartal));
-    }
-
-    @GetMapping(value = "/verif/datavarehus/sykefravar/virksomhet/{årstall}/{kvartal}")
-    public List<SykefraværsstatistikkVirksomhet> hentSykefraværsstatistikkVirksomhet(@PathVariable int årstall, @PathVariable int kvartal) {
-        return service.hentSykefraværsstatistikkVirksomhet(new ÅrstallOgKvartal(årstall, kvartal));
-    }
 
     @PostMapping(value = "/land/{årstall}/{kvartal}")
     public SlettOgOpprettResultat importSykefraværsstatistikkLand(@PathVariable int årstall, @PathVariable int kvartal) {

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportRepository.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportRepository.java
@@ -136,24 +136,29 @@ public class StatistikkImportRepository {
       return antallSlettet;
   }
 
-  int batchOpprett(
-          List<? extends Sykefraværsstatistikk> sykefraværsstatistikk,
-          SykefraværsstatistikkIntegrasjonUtils utils,
-          int insertBatchStørrelse
-  ) {
-    List<? extends List<? extends Sykefraværsstatistikk>> subsets =
-            Lists.partition(sykefraværsstatistikk, insertBatchStørrelse);
-    AtomicInteger antallOpprettet = new AtomicInteger();
+    int batchOpprett(
+            List<? extends Sykefraværsstatistikk> sykefraværsstatistikk,
+            SykefraværsstatistikkIntegrasjonUtils utils,
+            int insertBatchStørrelse
+    ) {
 
-    subsets.forEach( subset -> {
+        List<? extends List<? extends Sykefraværsstatistikk>> subsets =
+                Lists.partition(sykefraværsstatistikk, insertBatchStørrelse);
+        AtomicInteger antallOpprettet = new AtomicInteger();
+
+      /*
+        subsets.forEach( subset -> {
               int opprettet = utils.getBatchCreateFunction(subset).apply();
               int opprettetHittilNå = antallOpprettet.addAndGet(opprettet);
 
               log.info(String.format("Opprettet %d rader", opprettetHittilNå));
+              subset.clear();
             }
-    );
+        );*/
 
-    return antallOpprettet.get();
-  }
+        int opprettet = utils.getBatchCreateFunction(sykefraværsstatistikk).apply();
+        antallOpprettet.addAndGet(opprettet);
+        return antallOpprettet.get();
+    }
 
 }

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportRepository.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportRepository.java
@@ -38,7 +38,12 @@ public class StatistikkImportRepository {
     SykefraværsstatistikkLandUtils sykefraværsstatistikkLandUtils =
         new SykefraværsstatistikkLandUtils(namedParameterJdbcTemplate);
 
-    return importStatistikk(landStatistikk, årstallOgKvartal, sykefraværsstatistikkLandUtils);
+    return importStatistikk(
+            "land",
+            landStatistikk,
+            årstallOgKvartal,
+            sykefraværsstatistikkLandUtils
+    );
   }
 
   public SlettOgOpprettResultat importSykefraværsstatistikkSektor(
@@ -49,7 +54,12 @@ public class StatistikkImportRepository {
     SykefraværsstatistikkSektorUtils sykefraværsstatistikkSektorUtils =
             new SykefraværsstatistikkSektorUtils(namedParameterJdbcTemplate);
 
-    return importStatistikk(sykefraværsstatistikkSektor, årstallOgKvartal, sykefraværsstatistikkSektorUtils);
+    return importStatistikk(
+            "sektor",
+            sykefraværsstatistikkSektor,
+            årstallOgKvartal,
+            sykefraværsstatistikkSektorUtils
+    );
   }
 
   public SlettOgOpprettResultat importSykefraværsstatistikkNæring(
@@ -59,7 +69,12 @@ public class StatistikkImportRepository {
     SykefraværsstatistikkNæringUtils sykefraværsstatistikkNæringUtils =
             new SykefraværsstatistikkNæringUtils(namedParameterJdbcTemplate);
 
-    return importStatistikk(sykefraværsstatistikkNæring, årstallOgKvartal, sykefraværsstatistikkNæringUtils);
+    return importStatistikk(
+            "næring",
+            sykefraværsstatistikkNæring,
+            årstallOgKvartal,
+            sykefraværsstatistikkNæringUtils
+    );
   }
 
   public SlettOgOpprettResultat importSykefraværsstatistikkVirksomhet(
@@ -69,20 +84,43 @@ public class StatistikkImportRepository {
     SykefraværsstatistikkVirksomhetUtils sykefraværsstatistikkVirksomhetUtils =
             new SykefraværsstatistikkVirksomhetUtils(namedParameterJdbcTemplate);
 
-    return importStatistikk(sykefraværsstatistikkVirksomhet, årstallOgKvartal, sykefraværsstatistikkVirksomhetUtils);
+    return importStatistikk(
+            "virksomhet",
+            sykefraværsstatistikkVirksomhet,
+            årstallOgKvartal,
+            sykefraværsstatistikkVirksomhetUtils
+    );
   }
 
 
   SlettOgOpprettResultat importStatistikk(
+          String statistikktype,
           List<? extends Sykefraværsstatistikk> sykefraværsstatistikk,
           ÅrstallOgKvartal årstallOgKvartal,
           SykefraværsstatistikkIntegrasjonUtils sykefraværsstatistikkIntegrasjonUtils
   ) {
 
     if (sykefraværsstatistikk.isEmpty()) {
+      log.info(
+              String.format("Ingen sykefraværsstatistikk (%s) til import for årstall '%d' og kvartal '%d'. ",
+                      statistikktype,
+                      årstallOgKvartal.getÅrstall(),
+                      årstallOgKvartal.getKvartal()
+              )
+      );
       return SlettOgOpprettResultat.tomtResultat();
     }
 
+    log.info(
+            String.format(
+                    "Starter import av sykefraværsstatistikk (%s) for årstall '%d' og kvartal '%d'. " +
+                            "Skal importere %d rader",
+                    statistikktype,
+                    årstallOgKvartal.getÅrstall(),
+                    årstallOgKvartal.getKvartal(),
+                    sykefraværsstatistikk.size()
+            )
+    );
     int antallSletet = slett(årstallOgKvartal, sykefraværsstatistikkIntegrasjonUtils.getDeleteFunction());
     int antallOprettet = batchOpprett(
             sykefraværsstatistikk,
@@ -104,12 +142,6 @@ public class StatistikkImportRepository {
           CreateSykefraværsstatistikkFunction createFunction,
           int insertBatchStørrelse
   ) {
-    log.info(
-            String.format(
-                    "Starter import av sykefraværsstatistikk. Skal importere %d rader",
-                    sykefraværsstatistikk.size()
-            )
-    );
     List<? extends List<? extends Sykefraværsstatistikk>> subsets =
             Lists.partition(sykefraværsstatistikk, insertBatchStørrelse);
     AtomicInteger antallOpprettet = new AtomicInteger();

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportRepository.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportRepository.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Component
 public class StatistikkImportRepository {
 
-  public static final int INSERT_BATCH_STØRRELSE = 1000;
+  public static final int INSERT_BATCH_STØRRELSE = 10000;
   private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
   public StatistikkImportRepository(

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportRepository.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportRepository.java
@@ -131,10 +131,10 @@ public class StatistikkImportRepository {
   }
 
 
-  private int slett(ÅrstallOgKvartal årstallOgKvartal, DeleteSykefraværsstatistikkFunction deleteFunction) {
-      int antallSlettet = deleteFunction.apply(årstallOgKvartal);
-      return antallSlettet;
-  }
+    private int slett(ÅrstallOgKvartal årstallOgKvartal, DeleteSykefraværsstatistikkFunction deleteFunction) {
+        int antallSlettet = deleteFunction.apply(årstallOgKvartal);
+        return antallSlettet;
+    }
 
     int batchOpprett(
             List<? extends Sykefraværsstatistikk> sykefraværsstatistikk,
@@ -144,20 +144,17 @@ public class StatistikkImportRepository {
 
         List<? extends List<? extends Sykefraværsstatistikk>> subsets =
                 Lists.partition(sykefraværsstatistikk, insertBatchStørrelse);
+
         AtomicInteger antallOpprettet = new AtomicInteger();
 
-      /*
-        subsets.forEach( subset -> {
-              int opprettet = utils.getBatchCreateFunction(subset).apply();
-              int opprettetHittilNå = antallOpprettet.addAndGet(opprettet);
+        subsets.forEach(subset -> {
+                    int opprettet = utils.getBatchCreateFunction(subset).apply();
+                    int opprettetHittilNå = antallOpprettet.addAndGet(opprettet);
 
-              log.info(String.format("Opprettet %d rader", opprettetHittilNå));
-              subset.clear();
-            }
-        );*/
+                    log.info(String.format("Opprettet %d rader", opprettetHittilNå));
+                }
+        );
 
-        int opprettet = utils.getBatchCreateFunction(sykefraværsstatistikk).apply();
-        antallOpprettet.addAndGet(opprettet);
         return antallOpprettet.get();
     }
 

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportService.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportService.java
@@ -24,22 +24,6 @@ public class StatistikkImportService {
         this.statistikkImportRepository = statistikkImportRepository;
     }
 
-    // TODO: DELETE ME --> bare til versifisering
-    public List<SykefraværsstatistikkLand> hentSykefraværsstatistikkLand(ÅrstallOgKvartal årstallOgKvartal) {
-        return datavarehusRepository.hentSykefraværsstatistikkLand(årstallOgKvartal);
-    }
-
-    public List<SykefraværsstatistikkSektor> hentSykefraværsstatistikkSektor(ÅrstallOgKvartal årstallOgKvartal) {
-        return datavarehusRepository.hentSykefraværsstatistikkSektor(årstallOgKvartal);
-    }
-
-    public List<SykefraværsstatistikkNæring> hentSykefraværsstatistikkNæring(ÅrstallOgKvartal årstallOgKvartal) {
-        return datavarehusRepository.hentSykefraværsstatistikkNæring(årstallOgKvartal);
-    }
-
-    public List<SykefraværsstatistikkVirksomhet> hentSykefraværsstatistikkVirksomhet(ÅrstallOgKvartal årstallOgKvartal) {
-        return datavarehusRepository.hentSykefraværsstatistikkVirksomhet(årstallOgKvartal);
-    }
 
     public SlettOgOpprettResultat importSykefraværsstatistikkLand(ÅrstallOgKvartal årstallOgKvartal) {
         List<SykefraværsstatistikkLand> sykefraværsstatistikkLand =

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/BatchCreateSykefraværsstatistikkFunction.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/BatchCreateSykefraværsstatistikkFunction.java
@@ -1,6 +1,6 @@
 package no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon;
 
 @FunctionalInterface
-public interface CreateSykefraværsstatistikkFunction<T> {
-    int apply(T t);
+public interface BatchCreateSykefraværsstatistikkFunction {
+    int apply();
 }

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkIntegrasjonUtils.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkIntegrasjonUtils.java
@@ -1,11 +1,14 @@
 package no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.utils;
 
-import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.CreateSykefraværsstatistikkFunction;
+import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.Sykefraværsstatistikk;
+import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.BatchCreateSykefraværsstatistikkFunction;
 import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.DeleteSykefraværsstatistikkFunction;
+
+import java.util.List;
 
 public interface SykefraværsstatistikkIntegrasjonUtils {
 
     DeleteSykefraværsstatistikkFunction getDeleteFunction();
-    CreateSykefraværsstatistikkFunction getCreateFunction();
+    BatchCreateSykefraværsstatistikkFunction getBatchCreateFunction(List<? extends Sykefraværsstatistikk> list);
 
 }

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkLandUtils.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkLandUtils.java
@@ -1,66 +1,64 @@
 package no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.utils;
 
-import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.SykefraværsstatistikkLand;
+import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.Sykefraværsstatistikk;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.ÅrstallOgKvartal;
-import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.CreateSykefraværsstatistikkFunction;
+import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.BatchCreateSykefraværsstatistikkFunction;
 import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.DeleteSykefraværsstatistikkFunction;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class SykefraværsstatistikkLandUtils extends SykefraværsstatistikkIntegrasjon
-    implements SykefraværsstatistikkIntegrasjonUtils {
+        implements SykefraværsstatistikkIntegrasjonUtils {
 
 
-  public SykefraværsstatistikkLandUtils(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
-    super(namedParameterJdbcTemplate);
-  }
+    public SykefraværsstatistikkLandUtils(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
+        super(namedParameterJdbcTemplate);
+    }
 
-  @Override
-  public DeleteSykefraværsstatistikkFunction getDeleteFunction() {
-    DeleteSykefraværsstatistikkFunction function =
-        (ÅrstallOgKvartal årstallOgKvartal) -> {
-          SqlParameterSource namedParameters =
-              new MapSqlParameterSource()
-                  .addValue(ARSTALL, årstallOgKvartal.getÅrstall())
-                  .addValue(KVARTAL, årstallOgKvartal.getKvartal());
+    @Override
+    public DeleteSykefraværsstatistikkFunction getDeleteFunction() {
+        DeleteSykefraværsstatistikkFunction function =
+                (ÅrstallOgKvartal årstallOgKvartal) -> {
+                    SqlParameterSource namedParameters =
+                            new MapSqlParameterSource()
+                                    .addValue(ARSTALL, årstallOgKvartal.getÅrstall())
+                                    .addValue(KVARTAL, årstallOgKvartal.getKvartal());
 
-          int antallSlettet =
-              namedParameterJdbcTemplate.update(
-                  String.format(
-                      "delete from sykefravar_statistikk_land where arstall = :%s and kvartal = :%s",
-                      ARSTALL, KVARTAL),
-                  namedParameters);
-          return antallSlettet;
-        };
-    return function;
-  }
+                    int antallSlettet =
+                            namedParameterJdbcTemplate.update(
+                                    String.format(
+                                            "delete from sykefravar_statistikk_land where arstall = :%s and kvartal = :%s",
+                                            ARSTALL, KVARTAL),
+                                    namedParameters);
+                    return antallSlettet;
+                };
+        return function;
+    }
 
-  @Override
-  public CreateSykefraværsstatistikkFunction getCreateFunction() {
-    CreateSykefraværsstatistikkFunction<SykefraværsstatistikkLand> function =
-        (SykefraværsstatistikkLand sykefraværsstatistikkLand) -> {
-          SqlParameterSource namedParameters =
-              new MapSqlParameterSource()
-                  .addValue(ARSTALL, sykefraværsstatistikkLand.getÅrstall())
-                  .addValue(KVARTAL, sykefraværsstatistikkLand.getKvartal())
-                  .addValue(ANTALL_PERSONER, sykefraværsstatistikkLand.getAntallPersoner())
-                  .addValue(TAPTE_DAGSVERK, sykefraværsstatistikkLand.getTapteDagsverk())
-                  .addValue(MULIGE_DAGSVERK, sykefraværsstatistikkLand.getMuligeDagsverk());
+    @Override
+    public BatchCreateSykefraværsstatistikkFunction getBatchCreateFunction(
+            List<? extends Sykefraværsstatistikk> statistikk
+    ) {
 
-          return namedParameterJdbcTemplate.update(
-              String.format(
-                  "insert into sykefravar_statistikk_land " +
-                          "(arstall, kvartal, antall_personer, tapte_dagsverk, mulige_dagsverk)  " +
-                          "values (:arstall, :kvartal, :antall_personer, :tapte_dagsverk, :mulige_dagsverk)",
-                  ARSTALL,
-                  KVARTAL,
-                  ANTALL_PERSONER,
-                  TAPTE_DAGSVERK,
-                  MULIGE_DAGSVERK),
-              namedParameters);
-        };
+        BatchCreateSykefraværsstatistikkFunction function =
+                () -> {
+                    SqlParameterSource[] batch = SqlParameterSourceUtils.createBatch(statistikk.toArray());
 
-    return function;
-  }
+                    int[] results = namedParameterJdbcTemplate.batchUpdate(
+                            "insert into sykefravar_statistikk_land " +
+                                    "(arstall, kvartal, antall_personer, tapte_dagsverk, mulige_dagsverk) " +
+                                    "values " +
+                                    "(:årstall, :kvartal, :antallPersoner, :tapteDagsverk, :muligeDagsverk)",
+                            batch);
+                    return Arrays.stream(results).sum();
+                };
+
+        return function;
+    }
+
 }

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkNæringUtils.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkNæringUtils.java
@@ -1,69 +1,64 @@
 package no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.utils;
 
-import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.SykefraværsstatistikkNæring;
+import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.Sykefraværsstatistikk;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.ÅrstallOgKvartal;
-import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.CreateSykefraværsstatistikkFunction;
+import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.BatchCreateSykefraværsstatistikkFunction;
 import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.DeleteSykefraværsstatistikkFunction;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class SykefraværsstatistikkNæringUtils extends SykefraværsstatistikkIntegrasjon
-    implements SykefraværsstatistikkIntegrasjonUtils {
+        implements SykefraværsstatistikkIntegrasjonUtils {
 
 
-  public SykefraværsstatistikkNæringUtils(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
-    super(namedParameterJdbcTemplate);
-  }
+    public SykefraværsstatistikkNæringUtils(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
+        super(namedParameterJdbcTemplate);
+    }
 
-  @Override
-  public DeleteSykefraværsstatistikkFunction getDeleteFunction() {
-    DeleteSykefraværsstatistikkFunction function =
-        (ÅrstallOgKvartal årstallOgKvartal) -> {
-          SqlParameterSource namedParameters =
-              new MapSqlParameterSource()
-                  .addValue(ARSTALL, årstallOgKvartal.getÅrstall())
-                  .addValue(KVARTAL, årstallOgKvartal.getKvartal());
+    @Override
+    public DeleteSykefraværsstatistikkFunction getDeleteFunction() {
+        DeleteSykefraværsstatistikkFunction function =
+                (ÅrstallOgKvartal årstallOgKvartal) -> {
+                    SqlParameterSource namedParameters =
+                            new MapSqlParameterSource()
+                                    .addValue(ARSTALL, årstallOgKvartal.getÅrstall())
+                                    .addValue(KVARTAL, årstallOgKvartal.getKvartal());
 
-          int antallSlettet =
-              namedParameterJdbcTemplate.update(
-                  String.format(
-                      "delete from sykefravar_statistikk_naring where arstall = :%s and kvartal = :%s",
-                      ARSTALL, KVARTAL),
-                  namedParameters);
-          return antallSlettet;
-        };
-    return function;
-  }
+                    int antallSlettet =
+                            namedParameterJdbcTemplate.update(
+                                    String.format(
+                                            "delete from sykefravar_statistikk_naring where arstall = :%s and kvartal = :%s",
+                                            ARSTALL, KVARTAL),
+                                    namedParameters);
+                    return antallSlettet;
+                };
+        return function;
+    }
 
-  @Override
-  public CreateSykefraværsstatistikkFunction getCreateFunction() {
-    CreateSykefraværsstatistikkFunction<SykefraværsstatistikkNæring> function =
-        (SykefraværsstatistikkNæring sykefraværsstatistikkNæring) -> {
-          SqlParameterSource namedParameters =
-              new MapSqlParameterSource()
-                  .addValue(ARSTALL, sykefraværsstatistikkNæring.getÅrstall())
-                  .addValue(KVARTAL, sykefraværsstatistikkNæring.getKvartal())
-                  .addValue(NÆRING_KODE, sykefraværsstatistikkNæring.getNæringkode())
-                  .addValue(ANTALL_PERSONER, sykefraværsstatistikkNæring.getAntallPersoner())
-                  .addValue(TAPTE_DAGSVERK, sykefraværsstatistikkNæring.getTapteDagsverk())
-                  .addValue(MULIGE_DAGSVERK, sykefraværsstatistikkNæring.getMuligeDagsverk());
+    @Override
+    public BatchCreateSykefraværsstatistikkFunction getBatchCreateFunction(
+            List<? extends Sykefraværsstatistikk> statistikk
+    ) {
 
-          return namedParameterJdbcTemplate.update(
-              String.format(
-                  "insert into sykefravar_statistikk_naring " +
-                          "(arstall, kvartal, naring_kode, antall_personer, tapte_dagsverk, mulige_dagsverk)  " +
-                          "values " +
-                          "(:arstall, :kvartal, :naring_kode, :antall_personer, :tapte_dagsverk, :mulige_dagsverk)",
-                  ARSTALL,
-                  KVARTAL,
-                  NÆRING_KODE,
-                  ANTALL_PERSONER,
-                  TAPTE_DAGSVERK,
-                  MULIGE_DAGSVERK),
-              namedParameters);
-        };
+        BatchCreateSykefraværsstatistikkFunction function =
+                () -> {
+                    SqlParameterSource[] batch = SqlParameterSourceUtils.createBatch(statistikk.toArray());
 
-    return function;
-  }
+                    int[] results = namedParameterJdbcTemplate.batchUpdate(
+                            "insert into sykefravar_statistikk_naring " +
+                                    "(arstall, kvartal, naring_kode, antall_personer, tapte_dagsverk, mulige_dagsverk) " +
+                                    "values " +
+                                    "(:årstall, :kvartal, :næringkode, :antallPersoner, :tapteDagsverk, :muligeDagsverk)",
+                            batch);
+                    return Arrays.stream(results).sum();
+                };
+
+        return function;
+    }
+
 }

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkSektorUtils.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkSektorUtils.java
@@ -1,69 +1,64 @@
 package no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.utils;
 
-import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.SykefraværsstatistikkSektor;
+import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.Sykefraværsstatistikk;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.ÅrstallOgKvartal;
-import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.CreateSykefraværsstatistikkFunction;
+import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.BatchCreateSykefraværsstatistikkFunction;
 import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.DeleteSykefraværsstatistikkFunction;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class SykefraværsstatistikkSektorUtils extends SykefraværsstatistikkIntegrasjon
-    implements SykefraværsstatistikkIntegrasjonUtils {
+        implements SykefraværsstatistikkIntegrasjonUtils {
 
 
-  public SykefraværsstatistikkSektorUtils(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
-    super(namedParameterJdbcTemplate);
-  }
+    public SykefraværsstatistikkSektorUtils(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
+        super(namedParameterJdbcTemplate);
+    }
 
-  @Override
-  public DeleteSykefraværsstatistikkFunction getDeleteFunction() {
-    DeleteSykefraværsstatistikkFunction function =
-        (ÅrstallOgKvartal årstallOgKvartal) -> {
-          SqlParameterSource namedParameters =
-              new MapSqlParameterSource()
-                  .addValue(ARSTALL, årstallOgKvartal.getÅrstall())
-                  .addValue(KVARTAL, årstallOgKvartal.getKvartal());
+    @Override
+    public DeleteSykefraværsstatistikkFunction getDeleteFunction() {
+        DeleteSykefraværsstatistikkFunction function =
+                (ÅrstallOgKvartal årstallOgKvartal) -> {
+                    SqlParameterSource namedParameters =
+                            new MapSqlParameterSource()
+                                    .addValue(ARSTALL, årstallOgKvartal.getÅrstall())
+                                    .addValue(KVARTAL, årstallOgKvartal.getKvartal());
 
-          int antallSlettet =
-              namedParameterJdbcTemplate.update(
-                  String.format(
-                      "delete from sykefravar_statistikk_sektor where arstall = :%s and kvartal = :%s",
-                      ARSTALL, KVARTAL),
-                  namedParameters);
-          return antallSlettet;
-        };
-    return function;
-  }
+                    int antallSlettet =
+                            namedParameterJdbcTemplate.update(
+                                    String.format(
+                                            "delete from sykefravar_statistikk_sektor where arstall = :%s and kvartal = :%s",
+                                            ARSTALL, KVARTAL),
+                                    namedParameters);
+                    return antallSlettet;
+                };
+        return function;
+    }
 
-  @Override
-  public CreateSykefraværsstatistikkFunction getCreateFunction() {
-    CreateSykefraværsstatistikkFunction<SykefraværsstatistikkSektor> function =
-        (SykefraværsstatistikkSektor sykefraværsstatistikkSektor) -> {
-          SqlParameterSource namedParameters =
-              new MapSqlParameterSource()
-                  .addValue(ARSTALL, sykefraværsstatistikkSektor.getÅrstall())
-                  .addValue(KVARTAL, sykefraværsstatistikkSektor.getKvartal())
-                  .addValue(SEKTOR_KODE, sykefraværsstatistikkSektor.getSektorkode())
-                  .addValue(ANTALL_PERSONER, sykefraværsstatistikkSektor.getAntallPersoner())
-                  .addValue(TAPTE_DAGSVERK, sykefraværsstatistikkSektor.getTapteDagsverk())
-                  .addValue(MULIGE_DAGSVERK, sykefraværsstatistikkSektor.getMuligeDagsverk());
+    @Override
+    public BatchCreateSykefraværsstatistikkFunction getBatchCreateFunction(
+            List<? extends Sykefraværsstatistikk> statistikk
+    ) {
 
-          return namedParameterJdbcTemplate.update(
-              String.format(
-                  "insert into sykefravar_statistikk_sektor " +
-                          "(arstall, kvartal, sektor_kode, antall_personer, tapte_dagsverk, mulige_dagsverk)  " +
-                          "values " +
-                          "(:arstall, :kvartal, :sektor_kode, :antall_personer, :tapte_dagsverk, :mulige_dagsverk)",
-                  ARSTALL,
-                  KVARTAL,
-                  SEKTOR_KODE,
-                  ANTALL_PERSONER,
-                  TAPTE_DAGSVERK,
-                  MULIGE_DAGSVERK),
-              namedParameters);
-        };
+        BatchCreateSykefraværsstatistikkFunction function =
+                () -> {
+                    SqlParameterSource[] batch = SqlParameterSourceUtils.createBatch(statistikk.toArray());
 
-    return function;
-  }
+                    int[] results = namedParameterJdbcTemplate.batchUpdate(
+                            "insert into sykefravar_statistikk_sektor " +
+                                    "(arstall, kvartal, sektor_kode, antall_personer, tapte_dagsverk, mulige_dagsverk) " +
+                                    "values " +
+                                    "(:årstall, :kvartal, :sektorkode, :antallPersoner, :tapteDagsverk, :muligeDagsverk)",
+                            batch);
+                    return Arrays.stream(results).sum();
+                };
+
+        return function;
+    }
+
 }

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkVirksomhetUtils.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkVirksomhetUtils.java
@@ -1,69 +1,64 @@
 package no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.utils;
 
-import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.SykefraværsstatistikkVirksomhet;
+import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.Sykefraværsstatistikk;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.ÅrstallOgKvartal;
-import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.CreateSykefraværsstatistikkFunction;
+import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.BatchCreateSykefraværsstatistikkFunction;
 import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.DeleteSykefraværsstatistikkFunction;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class SykefraværsstatistikkVirksomhetUtils extends SykefraværsstatistikkIntegrasjon
-    implements SykefraværsstatistikkIntegrasjonUtils {
+        implements SykefraværsstatistikkIntegrasjonUtils {
 
 
-  public SykefraværsstatistikkVirksomhetUtils(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
-    super(namedParameterJdbcTemplate);
-  }
+    public SykefraværsstatistikkVirksomhetUtils(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
+        super(namedParameterJdbcTemplate);
+    }
 
-  @Override
-  public DeleteSykefraværsstatistikkFunction getDeleteFunction() {
-    DeleteSykefraværsstatistikkFunction function =
-        (ÅrstallOgKvartal årstallOgKvartal) -> {
-          SqlParameterSource namedParameters =
-              new MapSqlParameterSource()
-                  .addValue(ARSTALL, årstallOgKvartal.getÅrstall())
-                  .addValue(KVARTAL, årstallOgKvartal.getKvartal());
+    @Override
+    public DeleteSykefraværsstatistikkFunction getDeleteFunction() {
+        DeleteSykefraværsstatistikkFunction function =
+                (ÅrstallOgKvartal årstallOgKvartal) -> {
+                    SqlParameterSource namedParameters =
+                            new MapSqlParameterSource()
+                                    .addValue(ARSTALL, årstallOgKvartal.getÅrstall())
+                                    .addValue(KVARTAL, årstallOgKvartal.getKvartal());
 
-          int antallSlettet =
-              namedParameterJdbcTemplate.update(
-                  String.format(
-                      "delete from sykefravar_statistikk_virksomhet where arstall = :%s and kvartal = :%s",
-                      ARSTALL, KVARTAL),
-                  namedParameters);
-          return antallSlettet;
-        };
-    return function;
-  }
+                    int antallSlettet =
+                            namedParameterJdbcTemplate.update(
+                                    String.format(
+                                            "delete from sykefravar_statistikk_virksomhet where arstall = :%s and kvartal = :%s",
+                                            ARSTALL, KVARTAL),
+                                    namedParameters);
+                    return antallSlettet;
+                };
+        return function;
+    }
 
-  @Override
-  public CreateSykefraværsstatistikkFunction getCreateFunction() {
-    CreateSykefraværsstatistikkFunction<SykefraværsstatistikkVirksomhet> function =
-        (SykefraværsstatistikkVirksomhet sykefraværsstatistikkVirksomhet) -> {
-          SqlParameterSource namedParameters =
-              new MapSqlParameterSource()
-                  .addValue(ARSTALL, sykefraværsstatistikkVirksomhet.getÅrstall())
-                  .addValue(KVARTAL, sykefraværsstatistikkVirksomhet.getKvartal())
-                  .addValue(ORGNR, sykefraværsstatistikkVirksomhet.getOrgnr())
-                  .addValue(ANTALL_PERSONER, sykefraværsstatistikkVirksomhet.getAntallPersoner())
-                  .addValue(TAPTE_DAGSVERK, sykefraværsstatistikkVirksomhet.getTapteDagsverk())
-                  .addValue(MULIGE_DAGSVERK, sykefraværsstatistikkVirksomhet.getMuligeDagsverk());
+    @Override
+    public BatchCreateSykefraværsstatistikkFunction getBatchCreateFunction(
+            List<? extends Sykefraværsstatistikk> statistikk
+    ) {
 
-          return namedParameterJdbcTemplate.update(
-              String.format(
-                  "insert into sykefravar_statistikk_virksomhet " +
-                          "(arstall, kvartal, orgnr, antall_personer, tapte_dagsverk, mulige_dagsverk)  " +
-                          "values " +
-                          "(:arstall, :kvartal, :orgnr, :antall_personer, :tapte_dagsverk, :mulige_dagsverk)",
-                  ARSTALL,
-                  KVARTAL,
-                  ORGNR,
-                  ANTALL_PERSONER,
-                  TAPTE_DAGSVERK,
-                  MULIGE_DAGSVERK),
-              namedParameters);
-        };
+        BatchCreateSykefraværsstatistikkFunction function =
+                () -> {
+                    SqlParameterSource[] batch = SqlParameterSourceUtils.createBatch(statistikk.toArray());
 
-    return function;
-  }
+                    int[] results = namedParameterJdbcTemplate.batchUpdate(
+                            "insert into sykefravar_statistikk_virksomhet " +
+                                    "(arstall, kvartal, orgnr, antall_personer, tapte_dagsverk, mulige_dagsverk)  " +
+                                    "values " +
+                                    "(:årstall, :kvartal, :orgnr, :antallPersoner, :tapteDagsverk, :muligeDagsverk)",
+                            batch);
+                    return Arrays.stream(results).sum();
+                };
+
+        return function;
+    }
+
 }

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/synkronisering/VirksomhetsklassifikasjonerSynkroniseringController.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/synkronisering/VirksomhetsklassifikasjonerSynkroniseringController.java
@@ -3,15 +3,11 @@ package no.nav.tag.sykefravarsstatistikk.api.provisjonering.synkronisering;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.security.oidc.api.Protected;
 import no.nav.tag.sykefravarsstatistikk.api.common.OpprettEllerOppdaterResultat;
-import no.nav.tag.sykefravarsstatistikk.api.domene.virksomhetsklassifikasjoner.Sektor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @Profile({"local", "dev"})
 @Protected
@@ -27,10 +23,6 @@ public class VirksomhetsklassifikasjonerSynkroniseringController {
         this.service = service;
     }
 
-    @GetMapping(value = "/verif/datavarehus/sektorer")
-    public List<Sektor> hentSektorer() {
-        return service.hentSektorer();
-    }
 
     @PostMapping(value = "/sektorer")
     public OpprettEllerOppdaterResultat populerSektorer() {

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/synkronisering/VirksomhetsklassifikasjonerSynkroniseringService.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/synkronisering/VirksomhetsklassifikasjonerSynkroniseringService.java
@@ -42,17 +42,6 @@ public class VirksomhetsklassifikasjonerSynkroniseringService {
     }
 
     public OpprettEllerOppdaterResultat populerNæringskoder() {
-        return populerNæringer();
-    }
-
-    // TODO: DELETE ME --> bare til versifisering
-    public List<Sektor> hentSektorer() {
-        return datavarehusRepository.hentAlleSektorer();
-    }
-
-
-
-    private OpprettEllerOppdaterResultat populerNæringer() {
 
         List<Næring> næringer = datavarehusRepository.hentAlleNæringer();
         OpprettEllerOppdaterResultat resultat =
@@ -66,6 +55,5 @@ public class VirksomhetsklassifikasjonerSynkroniseringService {
         );
         return resultat;
     }
-
 
 }

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/verifikasjon/SammenligningVerifikasjonController.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/verifikasjon/SammenligningVerifikasjonController.java
@@ -1,0 +1,75 @@
+package no.nav.tag.sykefravarsstatistikk.api.verifikasjon;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.security.oidc.api.Protected;
+import no.nav.tag.sykefravarsstatistikk.api.domene.Orgnr;
+import no.nav.tag.sykefravarsstatistikk.api.domene.sammenligning.Sykefraværprosent;
+import no.nav.tag.sykefravarsstatistikk.api.enhetsregisteret.Næringskode5Siffer;
+import no.nav.tag.sykefravarsstatistikk.api.enhetsregisteret.Underenhet;
+import no.nav.tag.sykefravarsstatistikk.api.sammenligning.SammenligningRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile({"dev", "local"})
+@Protected
+@RestController
+@Slf4j
+@RequestMapping(value = "/verifikasjon")
+public class SammenligningVerifikasjonController {
+
+    private final SammenligningRepository sykefravarprosentRepository;
+    @Autowired
+    public SammenligningVerifikasjonController(SammenligningRepository sykefravarprosentRepository){
+        this.sykefravarprosentRepository = sykefravarprosentRepository;
+    }
+
+    @GetMapping(value = "/{orgnr}/sykefravarsprosent/{årstall}/{kvartal}")
+    public Sykefraværprosent verifiserSykefraværsprosentUnderenhet(
+            @PathVariable("orgnr") String orgnrStr,
+            @PathVariable int årstall,
+            @PathVariable int kvartal
+    ) {
+        return sykefravarprosentRepository.hentSykefraværprosentVirksomhet(
+                årstall,
+                kvartal,
+                Underenhet.builder()
+                        .orgnr(new Orgnr(orgnrStr))
+                        .build()
+        );
+    }
+
+    @GetMapping(value = "/{naring}/sykefravarsprosent/{årstall}/{kvartal}")
+    public Sykefraværprosent verifiserSykefraværsprosentNæring(
+            @PathVariable String naring,
+            @PathVariable int årstall,
+            @PathVariable int kvartal
+    ) {
+        return sykefravarprosentRepository.hentSykefraværprosentNæring(
+                årstall,
+                kvartal,
+                new Næringskode5Siffer(naring, "")
+        );
+    }
+
+    @GetMapping(value = "/{sektor}/sykefravarsprosent/{årstall}/{kvartal}")
+    public Sykefraværprosent verifiserSykefraværsprosentSektor(
+            @PathVariable String sektor,
+            @PathVariable int årstall,
+            @PathVariable int kvartal
+    ) {
+        return sykefravarprosentRepository.hentSykefraværprosentSektor(årstall, kvartal, sektor);
+    }
+
+    @GetMapping(value = "/sykefravarsprosent/{årstall}/{kvartal}")
+    public Sykefraværprosent verifiserSykefraværsprosentSektor(
+            @PathVariable int årstall,
+            @PathVariable int kvartal
+    ) {
+        return sykefravarprosentRepository.hentSykefraværprosentLand(årstall, kvartal);
+    }
+
+}

--- a/src/main/java/no/nav/tag/sykefravarsstatistikk/api/virksomhetsklassifikasjoner/KlassifikasjonerRepository.java
+++ b/src/main/java/no/nav/tag/sykefravarsstatistikk/api/virksomhetsklassifikasjoner/KlassifikasjonerRepository.java
@@ -1,5 +1,6 @@
 package no.nav.tag.sykefravarsstatistikk.api.virksomhetsklassifikasjoner;
 
+import no.nav.tag.sykefravarsstatistikk.api.domene.virksomhetsklassifikasjoner.Næring;
 import no.nav.tag.sykefravarsstatistikk.api.domene.virksomhetsklassifikasjoner.Sektor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -33,6 +34,22 @@ public class KlassifikasjonerRepository {
                 (rs, rowNum) -> mapTilSektor(rs)
         );
     }
+
+    public Næring hentNæring(String kode) {
+        SqlParameterSource namedParameters = new MapSqlParameterSource()
+                .addValue("kode", kode);
+
+        return namedParameterJdbcTemplate.queryForObject(
+                "SELECT * FROM naring WHERE kode = :kode",
+                namedParameters,
+                (rs, rowNum) -> new Næring(
+                        rs.getString("kode"),
+                        rs.getString("navn")
+                )
+
+        );
+    }
+
 
     protected Sektor mapTilSektor(ResultSet rs) throws SQLException {
         return new Sektor(

--- a/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportRepositoryTest.java
+++ b/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportRepositoryTest.java
@@ -39,6 +39,7 @@ public class StatistikkImportRepositoryTest {
     public void importStatistikk__skal_ikke_slette_eksisterende_statistikk_når_det_ikke_er_noe_data_å_importere() {
 
         SlettOgOpprettResultat resultat = statistikkImportRepository.importStatistikk(
+                "Test stats",
                 Collections.emptyList(),
                 new ÅrstallOgKvartal(2019, 3),
                 getIntegrasjonUtils()

--- a/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportRepositoryTest.java
+++ b/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/StatistikkImportRepositoryTest.java
@@ -1,6 +1,7 @@
 package no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering;
 
 import no.nav.tag.sykefravarsstatistikk.api.common.SlettOgOpprettResultat;
+import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.SykefraværsstatistikkVirksomhet;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.ÅrstallOgKvartal;
 import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.CreateSykefraværsstatistikkFunction;
 import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.DeleteSykefraværsstatistikkFunction;
@@ -12,7 +13,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -43,6 +47,53 @@ public class StatistikkImportRepositoryTest {
         assertEquals(resultat, SlettOgOpprettResultat.tomtResultat());
     }
 
+    @Test
+    public void batchOpprett__deler_import_i_små_batch() {
+        List<SykefraværsstatistikkVirksomhet> list = getSykefraværsstatistikkVirksomhetList();
+
+        int resultat = statistikkImportRepository.batchOpprett(
+                list,
+                o -> 0,
+                2
+        );
+
+        assertEquals(resultat, 5);
+    }
+
+    @Test
+    public void batchOpprett__ikke_deler_dersom_batch_størrelse_er_større_enn_listen() {
+        List<SykefraværsstatistikkVirksomhet> list = getSykefraværsstatistikkVirksomhetList();
+
+        int resultat = statistikkImportRepository.batchOpprett(
+                list,
+                o -> 0,
+                1000
+        );
+
+        assertEquals(resultat, 5);
+    }
+
+
+    private static List<SykefraværsstatistikkVirksomhet> getSykefraværsstatistikkVirksomhetList() {
+        List<SykefraværsstatistikkVirksomhet> list = new ArrayList<>();
+        list.add(sykefraværsstatistikkVirksomhet(2018, 1));
+        list.add(sykefraværsstatistikkVirksomhet(2018, 2));
+        list.add(sykefraværsstatistikkVirksomhet(2018, 3));
+        list.add(sykefraværsstatistikkVirksomhet(2018, 4));
+        list.add(sykefraværsstatistikkVirksomhet(2019, 1));
+        return list;
+    }
+
+    private static SykefraværsstatistikkVirksomhet sykefraværsstatistikkVirksomhet(int årstall, int kvartal) {
+        return new SykefraværsstatistikkVirksomhet(
+                årstall,
+                kvartal,
+                "987654321",
+                10,
+                new BigDecimal(15),
+                new BigDecimal(450)
+        );
+    }
 
     private static SykefraværsstatistikkIntegrasjonUtils getIntegrasjonUtils() {
         return new SykefraværsstatistikkIntegrasjonUtils() {

--- a/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkLandUtilsJdbcTest.java
+++ b/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkLandUtilsJdbcTest.java
@@ -3,7 +3,6 @@ package no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integras
 import no.nav.tag.sykefravarsstatistikk.api.domene.sammenligning.Sykefraværprosent;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.SykefraværsstatistikkLand;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.ÅrstallOgKvartal;
-import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.CreateSykefraværsstatistikkFunction;
 import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.DeleteSykefraværsstatistikkFunction;
 import org.junit.After;
 import org.junit.Before;
@@ -17,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,13 +47,29 @@ public class SykefraværsstatistikkLandUtilsJdbcTest {
 
 
     @Test
-    public void createFunction_apply__skal_lagre_data_i_lokale_sykefraværstatistikk_tabellen(){
-        CreateSykefraværsstatistikkFunction createFunction = utils.getCreateFunction();
-        createFunction.apply(new SykefraværsstatistikkLand(2019, 1, 14, new BigDecimal(55.123), new BigDecimal(856.891)));
+    public void createFunction_apply__skal_lagre_data_i_lokale_sykefraværstatistikk_tabellen() {
+        List<SykefraværsstatistikkLand> list = new ArrayList<>();
+        list.add(
+                new SykefraværsstatistikkLand(
+                        2019,
+                        1,
+                        14,
+                        new BigDecimal(55.123),
+                        new BigDecimal(856.891)
+                )
+        );
 
-        List<Sykefraværprosent> list = hentSykefraværprosentLand(namedParameterJdbcTemplate);
-        assertThat(list.size()).isEqualTo(1);
-        assertThat(list.get(0)).isEqualTo((new Sykefraværprosent(LABEL, new BigDecimal(55.123), new BigDecimal(856.891))));
+        utils.getBatchCreateFunction(list).apply();
+
+        List<Sykefraværprosent> resultList = hentSykefraværprosentLand(namedParameterJdbcTemplate);
+        assertThat(resultList.size()).isEqualTo(1);
+        assertThat(resultList.get(0)).isEqualTo((
+                        new Sykefraværprosent(LABEL,
+                                new BigDecimal(55.123),
+                                new BigDecimal(856.891)
+                        )
+                )
+        );
     }
 
     @Test

--- a/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkNæringUtilsJdbcTest.java
+++ b/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkNæringUtilsJdbcTest.java
@@ -3,7 +3,6 @@ package no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integras
 import no.nav.tag.sykefravarsstatistikk.api.domene.sammenligning.Sykefraværprosent;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.SykefraværsstatistikkNæring;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.ÅrstallOgKvartal;
-import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.CreateSykefraværsstatistikkFunction;
 import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.DeleteSykefraværsstatistikkFunction;
 import org.junit.After;
 import org.junit.Before;
@@ -17,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,8 +49,8 @@ public class SykefraværsstatistikkNæringUtilsJdbcTest {
 
     @Test
     public void createFunction_apply__skal_lagre_data_i_lokale_sykefraværstatistikk_tabellen(){
-        CreateSykefraværsstatistikkFunction createFunction = utils.getCreateFunction();
-        createFunction.apply(
+        List<SykefraværsstatistikkNæring> list = new ArrayList<>();
+        list.add(
                 new SykefraværsstatistikkNæring(
                         2019,
                         1,
@@ -61,9 +61,17 @@ public class SykefraværsstatistikkNæringUtilsJdbcTest {
                 )
         );
 
-        List<Sykefraværprosent> list = hentSykefraværprosentNæring(namedParameterJdbcTemplate);
-        assertThat(list.size()).isEqualTo(1);
-        assertThat(list.get(0)).isEqualTo((new Sykefraværprosent(LABEL, new BigDecimal(55.123), new BigDecimal(856.891))));
+        utils.getBatchCreateFunction(list).apply();
+
+        List<Sykefraværprosent> resultList = hentSykefraværprosentNæring(namedParameterJdbcTemplate);
+        assertThat(resultList .size()).isEqualTo(1);
+        assertThat(resultList .get(0)).isEqualTo(
+                new Sykefraværprosent(
+                        LABEL,
+                        new BigDecimal(55.123),
+                        new BigDecimal(856.891)
+                )
+        );
     }
 
     @Test

--- a/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkSektorUtilsJdbcTest.java
+++ b/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkSektorUtilsJdbcTest.java
@@ -3,7 +3,6 @@ package no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integras
 import no.nav.tag.sykefravarsstatistikk.api.domene.sammenligning.Sykefraværprosent;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.SykefraværsstatistikkSektor;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.ÅrstallOgKvartal;
-import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.CreateSykefraværsstatistikkFunction;
 import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.DeleteSykefraværsstatistikkFunction;
 import org.junit.After;
 import org.junit.Before;
@@ -17,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,8 +48,8 @@ public class SykefraværsstatistikkSektorUtilsJdbcTest {
 
     @Test
     public void createFunction_apply__skal_lagre_data_i_lokale_sykefraværstatistikk_tabellen(){
-        CreateSykefraværsstatistikkFunction createFunction = utils.getCreateFunction();
-        createFunction.apply(
+        List<SykefraværsstatistikkSektor> list = new ArrayList<>();
+        list.add(
                 new SykefraværsstatistikkSektor(
                         2019,
                         1,
@@ -58,11 +58,20 @@ public class SykefraværsstatistikkSektorUtilsJdbcTest {
                         new BigDecimal(55.123),
                         new BigDecimal(856.891)
                 )
+
         );
 
-        List<Sykefraværprosent> list = hentSykefraværprosentSektor(namedParameterJdbcTemplate);
-        assertThat(list.size()).isEqualTo(1);
-        assertThat(list.get(0)).isEqualTo((new Sykefraværprosent(LABEL, new BigDecimal(55.123), new BigDecimal(856.891))));
+        utils.getBatchCreateFunction(list).apply();
+
+        List<Sykefraværprosent> resultList = hentSykefraværprosentSektor(namedParameterJdbcTemplate);
+        assertThat(resultList .size()).isEqualTo(1);
+        assertThat(resultList.get(0)).isEqualTo(
+                new Sykefraværprosent(
+                        LABEL,
+                        new BigDecimal(55.123),
+                        new BigDecimal(856.891)
+                )
+        );
     }
 
     @Test

--- a/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkVirksomhetUtilsJdbcTest.java
+++ b/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkVirksomhetUtilsJdbcTest.java
@@ -78,6 +78,20 @@ public class SykefraværsstatistikkVirksomhetUtilsJdbcTest {
     }
 
 
+    @Test
+    public void createFunction_delete__skal_slette_data_i_lokale_sykefraværstatistikk_tabellen(){
+        lagreSykefraværprosentVirksomhet(namedParameterJdbcTemplate, "987654321", 2018, 3);
+        lagreSykefraværprosentVirksomhet(namedParameterJdbcTemplate, "987654321", 2018, 4);
+        lagreSykefraværprosentVirksomhet(namedParameterJdbcTemplate, "987654321", 2019, 1);
+
+        DeleteSykefraværsstatistikkFunction deleteFunction = utils.getDeleteFunction();
+        deleteFunction.apply(new ÅrstallOgKvartal(2018, 4));
+
+        List<Sykefraværprosent> list = hentSykefraværprosentVirksomhet(namedParameterJdbcTemplate);
+        assertThat(list.size()).isEqualTo(2);
+    }
+
+
     private List<SykefraværsstatistikkVirksomhet> createStatistikk(int antall) {
         List<SykefraværsstatistikkVirksomhet> list = new ArrayList<>();
 
@@ -94,20 +108,6 @@ public class SykefraværsstatistikkVirksomhetUtilsJdbcTest {
         );
         return list;
     }
-
-    @Test
-    public void createFunction_delete__skal_slette_data_i_lokale_sykefraværstatistikk_tabellen(){
-        lagreSykefraværprosentVirksomhet(namedParameterJdbcTemplate, "987654321", 2018, 3);
-        lagreSykefraværprosentVirksomhet(namedParameterJdbcTemplate, "987654321", 2018, 4);
-        lagreSykefraværprosentVirksomhet(namedParameterJdbcTemplate, "987654321", 2019, 1);
-
-        DeleteSykefraværsstatistikkFunction deleteFunction = utils.getDeleteFunction();
-        deleteFunction.apply(new ÅrstallOgKvartal(2018, 4));
-
-        List<Sykefraværprosent> list = hentSykefraværprosentVirksomhet(namedParameterJdbcTemplate);
-        assertThat(list.size()).isEqualTo(2);
-    }
-
 
     private static List<Sykefraværprosent> hentSykefraværprosentVirksomhet(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
 

--- a/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkVirksomhetUtilsJdbcTest.java
+++ b/src/test/java/no/nav/tag/sykefravarsstatistikk/api/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkVirksomhetUtilsJdbcTest.java
@@ -3,7 +3,7 @@ package no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integras
 import no.nav.tag.sykefravarsstatistikk.api.domene.sammenligning.Sykefraværprosent;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.SykefraværsstatistikkVirksomhet;
 import no.nav.tag.sykefravarsstatistikk.api.domene.statistikk.ÅrstallOgKvartal;
-import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.CreateSykefraværsstatistikkFunction;
+import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.BatchCreateSykefraværsstatistikkFunction;
 import no.nav.tag.sykefravarsstatistikk.api.provisjonering.importering.integrasjon.DeleteSykefraværsstatistikkFunction;
 import org.junit.After;
 import org.junit.Before;
@@ -17,7 +17,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -48,21 +50,49 @@ public class SykefraværsstatistikkVirksomhetUtilsJdbcTest {
 
     @Test
     public void createFunction_apply__skal_lagre_data_i_lokale_sykefraværstatistikk_tabellen(){
-        CreateSykefraværsstatistikkFunction createFunction = utils.getCreateFunction();
-        createFunction.apply(
-                new SykefraværsstatistikkVirksomhet(
-                        2019,
-                        1,
-                        "987654321",
-                        14,
-                        new BigDecimal(55.123),
-                        new BigDecimal(856.891)
+
+        List<SykefraværsstatistikkVirksomhet> list = new ArrayList<>();
+        list.add(new SykefraværsstatistikkVirksomhet(
+                2019,
+                1,
+                "987654321",
+                14,
+                new BigDecimal(55.123),
+                new BigDecimal(856.891)
+        ));
+
+        BatchCreateSykefraværsstatistikkFunction createFunction = utils.getBatchCreateFunction(list);
+        createFunction.apply();
+
+        List<Sykefraværprosent> resultList = hentSykefraværprosentVirksomhet(namedParameterJdbcTemplate);
+        assertThat(resultList.size()).isEqualTo(1);
+        assertThat(resultList.get(0)).isEqualTo((new Sykefraværprosent(LABEL, new BigDecimal(55.123), new BigDecimal(856.891))));
+    }
+
+    @Test
+    public void createFunction_apply__ytelsestest(){
+        utils.getBatchCreateFunction(createStatistikk(1000)).apply();
+
+        List<Sykefraværprosent> resultList = hentSykefraværprosentVirksomhet(namedParameterJdbcTemplate);
+        assertThat(resultList.size()).isEqualTo(1000);
+    }
+
+
+    private List<SykefraværsstatistikkVirksomhet> createStatistikk(int antall) {
+        List<SykefraværsstatistikkVirksomhet> list = new ArrayList<>();
+
+        IntStream.range(0, antall).forEach(
+                i -> list.add(new SykefraværsstatistikkVirksomhet(
+                                2019,
+                                1,
+                                Integer.valueOf(987000000 + i).toString(),
+                                14,
+                                new BigDecimal(55.123),
+                                new BigDecimal(856.891)
+                        )
                 )
         );
-
-        List<Sykefraværprosent> list = hentSykefraværprosentVirksomhet(namedParameterJdbcTemplate);
-        assertThat(list.size()).isEqualTo(1);
-        assertThat(list.get(0)).isEqualTo((new Sykefraværprosent(LABEL, new BigDecimal(55.123), new BigDecimal(856.891))));
+        return list;
     }
 
     @Test


### PR DESCRIPTION
Endringer i denne PR-en:
 - tilpasse konfig til imaget så det tåler en stor import (statistikk virksomhet)
 - dele ut storre import jobber så det er smallere datasets å lagre i DB + bedre logging
 - bruk av `jdbcTemplate.batchUpdate()` i stedet av  `jdbcTemplate.update()`
 - fjerne noen verifikasjon endepunkter

