### PR TITLE
Eksponere bedriftsmetrikker til videre bruk for tracking

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/RestResponseEntityExceptionHandler.java
@@ -3,8 +3,6 @@ package no.nav.arbeidsgiver.sykefravarsstatistikk.api;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.altinn.AltinnException;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.tilgangskontroll.TilgangskontrollException;
 import no.nav.security.spring.oidc.validation.interceptor.OIDCUnauthorizedException;
-import no.nav.arbeidsgiver.sykefravarsstatistikk.api.altinn.AltinnException;
-import no.nav.arbeidsgiver.sykefravarsstatistikk.api.tilgangskontroll.TilgangskontrollException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/metrikker/Bedriftsmetrikker.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/metrikker/Bedriftsmetrikker.java
@@ -1,0 +1,14 @@
+package no.nav.arbeidsgiver.sykefravarsstatistikk.api.metrikker;
+
+import lombok.Builder;
+import lombok.Data;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.enhetsregisteret.Næringskode5Siffer;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+public class Bedriftsmetrikker {
+    private BigDecimal antallAnsatte;
+    private Næringskode5Siffer næringskode5Siffer;
+}

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/metrikker/BedriftsmetrikkerController.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/metrikker/BedriftsmetrikkerController.java
@@ -1,0 +1,39 @@
+package no.nav.arbeidsgiver.sykefravarsstatistikk.api.metrikker;
+
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.domene.Orgnr;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.enhetsregisteret.EnhetsregisteretClient;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.enhetsregisteret.Underenhet;
+import no.nav.security.oidc.api.Unprotected;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.math.BigDecimal;
+
+@Unprotected
+@RestController
+public class BedriftsmetrikkerController {
+    private final EnhetsregisteretClient enhetsregisteretClient;
+
+    public BedriftsmetrikkerController(
+            EnhetsregisteretClient enhetsregisteretClient
+    ) {
+        this.enhetsregisteretClient = enhetsregisteretClient;
+    }
+
+    @GetMapping(value = "/{orgnr}/bedriftsmetrikker")
+    public Bedriftsmetrikker hentBedriftsmetrikker(
+            @PathVariable("orgnr") String orgnrStr,
+            HttpServletRequest request
+    ) {
+
+        Orgnr orgnr = new Orgnr(orgnrStr);
+        Underenhet underenhet = enhetsregisteretClient.hentInformasjonOmUnderenhet(orgnr);
+
+        return Bedriftsmetrikker.builder()
+                .antallAnsatte(new BigDecimal(underenhet.getAntallAnsatte()))
+                .næringskode5Siffer(underenhet.getNæringskode())
+                .build();
+    }
+}

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/ApiTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/ApiTest.java
@@ -38,6 +38,30 @@ public class ApiTest {
 
 
     @Test
+    public void bedriftsmetrikker__skal_returnere_riktig_objekt() throws Exception {
+        HttpResponse<String> response = newBuilder().build().send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + port + "/sykefravarsstatistikk-api/" + ORGNR_UNDERENHET + "/bedriftsmetrikker"))
+                        .header(AUTHORIZATION, "Bearer " + JwtTokenGenerator.signedJWTAsString("15008462396"))
+                        .GET()
+                        .build(),
+                ofString()
+        );
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        JsonNode bedriftsmetrikker = objectMapper.readTree(response.body());
+
+        assertThat(bedriftsmetrikker.get("næringskode5Siffer"))
+                .isEqualTo(objectMapper.readTree("{" +
+                        "        \"kode\": \"10300\"," +
+                        "        \"beskrivelse\": \"Trygdeordninger underlagt offentlig forvaltning\"" +
+                        "    }")
+                );
+
+        assertThat(bedriftsmetrikker.get("antallAnsatte")).isEqualTo(objectMapper.readTree("143"));
+    }
+
+    @Test
     public void sykefraværshistorikk__skal_returnere_riktig_objekt() throws Exception {
         HttpResponse<String> response = newBuilder().build().send(
                 HttpRequest.newBuilder()


### PR DESCRIPTION
Nytt endepunkt `/{orgnr}/bedriftsmetrikker` som returnerer `antallAnsatte` og `næringskode5Siffer` til en viss bedrift