### PR TITLE
legge til feilhåndtering for underenheter unten næringskode

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/MockServer.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/MockServer.java
@@ -53,6 +53,7 @@ public class MockServer {
         String path = new URL(enhetsregisteretUrl).getPath();
         mockKall(WireMock.urlPathMatching(path + "underenheter/[0-9]{9}"), lesFilSomString("enhetsregisteretUnderenhet.json"));
         mockKall(WireMock.urlPathMatching(path + "underenheter/444444444"), lesFilSomString("enhetsregisteretUnderenhet_444444444.json"));
+        mockKall(WireMock.urlPathMatching(path + "underenheter/555555555"), lesFilSomString("enhetsregisteretUnderenhet_555555555.json"));
         mockKall(WireMock.urlPathMatching(path + "underenheter/910562452"), lesFilSomString("dev_enhetsregisteretUnderenhet_910562452.json"));
         mockKall(WireMock.urlPathMatching(path + "underenheter/910562436"), lesFilSomString("dev_enhetsregisteretUnderenhet_910562436.json"));
         mockKall(WireMock.urlPathMatching(path + "enheter/[0-9]{9}"), lesFilSomString("enhetsregisteretEnhet.json"));

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/RestResponseEntityExceptionHandler.java
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api;
 
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.altinn.AltinnException;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.enhetsregisteret.EnhetsregisteretException;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.tilgangskontroll.TilgangskontrollException;
 import no.nav.security.spring.oidc.validation.interceptor.OIDCUnauthorizedException;
 import org.slf4j.Logger;
@@ -22,6 +23,14 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
 
     private static Logger logger = LoggerFactory.getLogger(ResponseEntityExceptionHandler.class);
 
+
+    @ExceptionHandler(value = {EnhetsregisteretException.class})
+    @ResponseBody
+    protected ResponseEntity<Object> handleEnhetsregisteretException(RuntimeException e, WebRequest webRequest) {
+        return getResponseEntity(e,
+                "Could not get all necessary data for this organization from enhetsregistret",
+                HttpStatus.BAD_REQUEST);
+    }
 
     @ExceptionHandler(value = {TilgangskontrollException.class})
     @ResponseBody

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/RestResponseEntityExceptionHandler.java
@@ -2,6 +2,7 @@ package no.nav.arbeidsgiver.sykefravarsstatistikk.api;
 
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.altinn.AltinnException;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.enhetsregisteret.EnhetsregisteretException;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.enhetsregisteret.EnhetsregisteretMappingException;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.tilgangskontroll.TilgangskontrollException;
 import no.nav.security.spring.oidc.validation.interceptor.OIDCUnauthorizedException;
 import org.slf4j.Logger;
@@ -24,7 +25,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
     private static Logger logger = LoggerFactory.getLogger(ResponseEntityExceptionHandler.class);
 
 
-    @ExceptionHandler(value = {EnhetsregisteretException.class})
+    @ExceptionHandler(value = {EnhetsregisteretMappingException.class})
     @ResponseBody
     protected ResponseEntity<Object> handleEnhetsregisteretException(RuntimeException e, WebRequest webRequest) {
         return getResponseEntity(e,

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/RestResponseEntityExceptionHandler.java
@@ -28,7 +28,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
     @ResponseBody
     protected ResponseEntity<Object> handleEnhetsregisteretException(RuntimeException e, WebRequest webRequest) {
         return getResponseEntity(e,
-                "Could not get all necessary data for this organization from enhetsregistret",
+                "Kunne ikke hente informasjon om enheten fra enhetsregisteret",
                 HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretClient.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretClient.java
@@ -39,8 +39,6 @@ public class EnhetsregisteretClient {
             OverordnetEnhet overordnetEnhet = mapTilEnhet(respons);
             validerReturnertOrgnr(orgnrTilEnhet, overordnetEnhet.getOrgnr());
             return overordnetEnhet;
-        } catch (HttpServerErrorException hsee) {
-            throw hsee;
         } catch (RestClientException e) {
             throw new EnhetsregisteretException("Feil ved kall til Enhetsregisteret", e);
         }
@@ -53,8 +51,6 @@ public class EnhetsregisteretClient {
             Underenhet underenhet = mapTilUnderenhet(respons);
             validerReturnertOrgnr(orgnrTilUnderenhet, underenhet.getOrgnr());
             return underenhet;
-        } catch (HttpServerErrorException hsee) {
-            throw hsee;
         } catch (RestClientException e) {
             throw new EnhetsregisteretException("Feil ved kall til Enhetsregisteret", e);
         }
@@ -75,7 +71,7 @@ public class EnhetsregisteretClient {
             );
 
         } catch (IOException | NullPointerException e) {
-            throw new EnhetsregisteretException("Feil ved kall til Enhetsregisteret. Kunne ikke parse respons.", e);
+            throw new EnhetsregisteretMappingException("Feil ved kall til Enhetsregisteret. Kunne ikke parse respons.", e);
         }
     }
 
@@ -104,7 +100,7 @@ public class EnhetsregisteretClient {
             );
 
         } catch (IOException | NullPointerException e) {
-            throw new EnhetsregisteretException("Feil ved kall til Enhetsregisteret. Kunne ikke parse respons.", e);
+            throw new EnhetsregisteretMappingException("Feil ved kall til Enhetsregisteret. Kunne ikke parse respons.", e);
         }
     }
 

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretClient.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretClient.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
@@ -38,6 +39,8 @@ public class EnhetsregisteretClient {
             OverordnetEnhet overordnetEnhet = mapTilEnhet(respons);
             validerReturnertOrgnr(orgnrTilEnhet, overordnetEnhet.getOrgnr());
             return overordnetEnhet;
+        } catch (HttpServerErrorException hsee) {
+            throw hsee;
         } catch (RestClientException e) {
             throw new EnhetsregisteretException("Feil ved kall til Enhetsregisteret", e);
         }
@@ -50,6 +53,8 @@ public class EnhetsregisteretClient {
             Underenhet underenhet = mapTilUnderenhet(respons);
             validerReturnertOrgnr(orgnrTilUnderenhet, underenhet.getOrgnr());
             return underenhet;
+        } catch (HttpServerErrorException hsee) {
+            throw hsee;
         } catch (RestClientException e) {
             throw new EnhetsregisteretException("Feil ved kall til Enhetsregisteret", e);
         }

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretMappingException.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretMappingException.java
@@ -1,0 +1,7 @@
+package no.nav.arbeidsgiver.sykefravarsstatistikk.api.enhetsregisteret;
+
+public class EnhetsregisteretMappingException extends RuntimeException {
+    EnhetsregisteretMappingException(String msg, Exception e) {
+        super(msg, e);
+    }
+}

--- a/src/main/resources/mock/enhetsregisteretUnderenhet_555555555.json
+++ b/src/main/resources/mock/enhetsregisteretUnderenhet_555555555.json
@@ -1,0 +1,10 @@
+{
+  "organisasjonsnummer": "5555555",
+  "navn": "SAMEIET TORSK OG MAKRELL",
+  "organisasjonsform": {
+    "kode": "AAFY",
+    "beskrivelse": "Virksomhet til ikke-næringsdrivende person"
+  },
+  "antallAnsatte": 0,
+  "overordnetEnhet": "999555555"
+}

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/ApiErrorMappingTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/ApiErrorMappingTest.java
@@ -52,7 +52,7 @@ public class ApiErrorMappingTest {
         assertThat(response.statusCode()).isEqualTo(400);
         assertThat(response.body()).isEqualTo(
                 "{" +
-                        "\"message\":\"Could not get all necessary data for this organization from enhetsregistret\"" +
+                        "\"message\":\"Kunne ikke hente informasjon om enheten fra enhetsregisteret\"" +
                 "}"
         );
     }

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/ApiErrorMappingTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/ApiErrorMappingTest.java
@@ -1,0 +1,59 @@
+package no.nav.arbeidsgiver.sykefravarsstatistikk.api;
+
+import no.nav.security.oidc.test.support.JwtTokenGenerator;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static java.net.http.HttpClient.newBuilder;
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"wiremock.mock.port=8083"})
+public class ApiErrorMappingTest {
+
+    @LocalServerPort
+    private String port;
+
+    private final static String ORGNR_UNDERENHET_UTEN_NÆRING = "555555555";
+
+
+    @Test
+    public void bedriftsmetrikker__skal_returnere_BAD_REQUEST_dersom_underenhet_ikke_har_noe_næringskode()
+            throws Exception {
+        HttpResponse<String> response = newBuilder().build().send(
+                HttpRequest.newBuilder()
+                        .uri(
+                                URI.create(
+                                        "http://localhost:" + port
+                                                + "/sykefravarsstatistikk-api/" + ORGNR_UNDERENHET_UTEN_NÆRING
+                                                + "/bedriftsmetrikker"
+                                )
+                        )
+                        .header(
+                                AUTHORIZATION,
+                                "Bearer " + JwtTokenGenerator.signedJWTAsString("15008462396")
+                        )
+                        .GET()
+                        .build(),
+                ofString()
+        );
+
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(response.body()).isEqualTo(
+                "{" +
+                        "\"message\":\"Could not get all necessary data for this organization from enhetsregistret\"" +
+                "}"
+        );
+    }
+}

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretClientTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretClientTest.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.etOrgnr;
@@ -46,6 +48,20 @@ public class EnhetsregisteretClientTest {
         assertThat(overordnetEnhet.getAntallAnsatte()).isEqualTo(40);
     }
 
+    @Test(expected = HttpServerErrorException.class)
+    public void hentInformasjonOmEnhet__skal_ikke_sperre_server_error__dersom_server_returnerer_5xx() {
+        when(
+                restTemplate.getForObject(
+                        anyString(),
+                        any()
+                )
+        ).thenThrow(
+                new HttpServerErrorException(HttpStatus.BAD_GATEWAY)
+        );
+
+        enhetsregisteretClient.hentInformasjonOmEnhet(etOrgnr());
+    }
+
     @Test(expected = EnhetsregisteretException.class)
     public void hentInformasjonOmEnhet__skal_feile_hvis_et_felt_mangler() {
         ObjectNode responsMedManglendeFelt = gyldigEnhetRespons("999263550");
@@ -75,6 +91,19 @@ public class EnhetsregisteretClientTest {
         assertThat(underenhet.getAntallAnsatte()).isEqualTo(40);
     }
 
+    @Test(expected = HttpServerErrorException.class)
+    public void hentInformasjonOmUnderenhet__skal_ikke_sperre_server_error__dersom_server_returnerer_5xx() {
+        when(
+                restTemplate.getForObject(
+                        anyString(),
+                        any()
+                )
+        ).thenThrow(
+                new HttpServerErrorException(HttpStatus.BAD_GATEWAY)
+        );
+
+        enhetsregisteretClient.hentInformasjonOmUnderenhet(etOrgnr());
+    }
     @Test(expected = EnhetsregisteretException.class)
     public void hentInformasjonOmUnderenhet__skal_feile_hvis_et_felt_mangler() {
         ObjectNode responsMedManglendeFelt = gyldigUnderenhetRespons("822565212");

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretClientTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretClientTest.java
@@ -48,8 +48,8 @@ public class EnhetsregisteretClientTest {
         assertThat(overordnetEnhet.getAntallAnsatte()).isEqualTo(40);
     }
 
-    @Test(expected = HttpServerErrorException.class)
-    public void hentInformasjonOmEnhet__skal_ikke_sperre_server_error__dersom_server_returnerer_5xx() {
+    @Test(expected = EnhetsregisteretException.class)
+    public void hentInformasjonOmEnhet__skal_feile_hvis_server_returnerer_5xx_server_returnerer_5xx() {
         when(
                 restTemplate.getForObject(
                         anyString(),
@@ -62,7 +62,7 @@ public class EnhetsregisteretClientTest {
         enhetsregisteretClient.hentInformasjonOmEnhet(etOrgnr());
     }
 
-    @Test(expected = EnhetsregisteretException.class)
+    @Test(expected = EnhetsregisteretMappingException.class)
     public void hentInformasjonOmEnhet__skal_feile_hvis_et_felt_mangler() {
         ObjectNode responsMedManglendeFelt = gyldigEnhetRespons("999263550");
         responsMedManglendeFelt.remove("institusjonellSektorkode");
@@ -91,8 +91,8 @@ public class EnhetsregisteretClientTest {
         assertThat(underenhet.getAntallAnsatte()).isEqualTo(40);
     }
 
-    @Test(expected = HttpServerErrorException.class)
-    public void hentInformasjonOmUnderenhet__skal_ikke_sperre_server_error__dersom_server_returnerer_5xx() {
+    @Test(expected = EnhetsregisteretException.class)
+    public void hentInformasjonOmUnderenhet__skal_feile_hvis_server_returnerer_5xx() {
         when(
                 restTemplate.getForObject(
                         anyString(),
@@ -104,7 +104,7 @@ public class EnhetsregisteretClientTest {
 
         enhetsregisteretClient.hentInformasjonOmUnderenhet(etOrgnr());
     }
-    @Test(expected = EnhetsregisteretException.class)
+    @Test(expected = EnhetsregisteretMappingException.class)
     public void hentInformasjonOmUnderenhet__skal_feile_hvis_et_felt_mangler() {
         ObjectNode responsMedManglendeFelt = gyldigUnderenhetRespons("822565212");
         responsMedManglendeFelt.remove("navn");


### PR DESCRIPTION
Bruker `ExceptionHanlder` mekanisme for å fange `EnhetsregisteretException` og returnere en `400` uten å logge noen `Error`