### PR TITLE
Lag egen respons for virksomheter uten næring

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretClient.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretClient.java
@@ -93,6 +93,10 @@ public class EnhetsregisteretClient {
             JsonNode enhetJson = objectMapper.readTree(jsonResponseFraEnhetsregisteret);
             JsonNode næringskodeJson = enhetJson.get("naeringskode1");
 
+            if (næringskodeJson == null) {
+                throw new IngenNæringException("Feil ved kall til Enhetsregisteret. Ingen næring for virksomhet.");
+            }
+
             return new Underenhet(
                     new Orgnr(enhetJson.get("organisasjonsnummer").textValue()),
                     new Orgnr(enhetJson.get("overordnetEnhet").textValue()),

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretMappingException.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/EnhetsregisteretMappingException.java
@@ -4,4 +4,8 @@ public class EnhetsregisteretMappingException extends RuntimeException {
     EnhetsregisteretMappingException(String msg, Exception e) {
         super(msg, e);
     }
+
+    EnhetsregisteretMappingException(String msg) {
+        super(msg);
+    }
 }

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/IngenNæringException.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/enhetsregisteret/IngenNæringException.java
@@ -1,0 +1,7 @@
+package no.nav.arbeidsgiver.sykefravarsstatistikk.api.enhetsregisteret;
+
+public class IngenNæringException extends RuntimeException {
+    IngenNæringException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/sykefraværshistorikk/SykefraværshistorikkController.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/sykefraværshistorikk/SykefraværshistorikkController.java
@@ -30,7 +30,7 @@ public class SykefraværshistorikkController {
         this.enhetsregisteretClient = enhetsregisteretClient;
     }
 
-    @GetMapping(value = "/{orgnr}/sykefravarshistorikk")
+        @GetMapping(value = "/{orgnr}/sykefravarshistorikk")
     public List<Sykefraværshistorikk> hentSykefraværshistorikk(
             @PathVariable("orgnr") String orgnrStr,
             HttpServletRequest request

--- a/src/main/resources/mock/altinnReportees.json
+++ b/src/main/resources/mock/altinnReportees.json
@@ -70,5 +70,13 @@
     "OrganizationNumber": "444444444",
     "OrganizationForm": "BEDR",
     "Status": "Active"
+  },
+  {
+    "Name": "NAV HAMAR 3",
+    "Type": "Business",
+    "ParentOrganizationNumber": "874652202",
+    "OrganizationNumber": "555555555",
+    "OrganizationForm": "BEDR",
+    "Status": "Active"
   }
 ]

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/ApiErrorMappingTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/ApiErrorMappingTest.java
@@ -29,7 +29,7 @@ public class ApiErrorMappingTest {
 
 
     @Test
-    public void bedriftsmetrikker__skal_returnere_SERVER_ERROR_med_causedBy_dersom_underenhet_ikke_har_noe_næringskode()
+    public void sykefraværshistorikk__skal_returnere_SERVER_ERROR_med_causedBy_dersom_underenhet_ikke_har_noe_næringskode()
             throws Exception {
         HttpResponse<String> response = newBuilder().build().send(
                 HttpRequest.newBuilder()

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/ApiErrorMappingTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/ApiErrorMappingTest.java
@@ -29,7 +29,7 @@ public class ApiErrorMappingTest {
 
 
     @Test
-    public void bedriftsmetrikker__skal_returnere_BAD_REQUEST_dersom_underenhet_ikke_har_noe_næringskode()
+    public void bedriftsmetrikker__skal_returnere_SERVER_ERROR_med_causedBy_dersom_underenhet_ikke_har_noe_næringskode()
             throws Exception {
         HttpResponse<String> response = newBuilder().build().send(
                 HttpRequest.newBuilder()
@@ -37,7 +37,7 @@ public class ApiErrorMappingTest {
                                 URI.create(
                                         "http://localhost:" + port
                                                 + "/sykefravarsstatistikk-api/" + ORGNR_UNDERENHET_UTEN_NÆRING
-                                                + "/bedriftsmetrikker"
+                                                + "/sykefravarshistorikk"
                                 )
                         )
                         .header(
@@ -49,7 +49,7 @@ public class ApiErrorMappingTest {
                 ofString()
         );
 
-        assertThat(response.statusCode()).isEqualTo(400);
-        assertThat(response.body()).isEqualTo("{\"message\":\"Kunne ikke hente informasjon om enheten fra enhetsregisteret\"}");
+        assertThat(response.statusCode()).isEqualTo(500);
+        assertThat(response.body()).isEqualTo("{\"message\":\"Internal error\",\"causedBy\":\"INGEN_NÆRING\"}");
     }
 }


### PR DESCRIPTION
Legger til en `causedBy: "INGEN_NÆRING"` på feilresponsen, hvis virksomheten ikke har en næring. Dette kan da plukkes opp i frontend for å gi bedre feilmelinger.  

Og fordi dette egentlig er en feil hos oss - det er jo gyldig at en virksomhet ikke har en næring - så gir jeg 500 i stedet for 400 i responsen