### PR TITLE
Bruk LegacyCookieProcessor for å ikke logge cookies

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/config/TomcatConfig.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/config/TomcatConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 // Tomcat logger feilformaterte cookies by default. Dette er et sikkerhetshull.
 // Her fikser vi dette ved å bruke LegacyCookieProcessor, som ikke logger slike.
+// Se https://www.jvt.me/posts/2020/04/07/tomcat-cookie-disclosure/ for mer informasjon.
 @Configuration
 public class TomcatConfig {
     @Bean


### PR DESCRIPTION
Kan testes ved å kjøre:
`curl --cookie "userId=wibble,this=logged" http://localhost:8080/sykefravarsstatistikk-api/internal/healthcheck`
Uten ny config vil det logges "A cookie header was received ..."

ref: 
https://nav-it.slack.com/archives/C6UBU9EAU/p1599140965016100
https://www.jvt.me/posts/2020/04/07/tomcat-cookie-disclosure/