### PR TITLE
Bytt til gcp-versjon av altinn-proxy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/oppgradere-avhengigheter-jan-2021'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/altinn-proxy-gcp'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -117,7 +117,7 @@ altinn:
   apikey: ${ALTINN_APIKEY}
   apigw.apikey: ${ALTINN_APIGW_APIKEY}
   proxy:
-    url: https://arbeidsgiver.nais.preprod.local/altinn-rettigheter-proxy
+    url: https://arbeidsgiver.dev.intern.nav.no/altinn-rettigheter-proxy
   iaweb.service:
     code: 3403
     edition: 1
@@ -153,7 +153,7 @@ altinn:
   apikey: ${ALTINN_APIKEY}
   apigw.apikey: ${ALTINN_APIGW_APIKEY}
   proxy:
-    url: https://arbeidsgiver.nais.adeo.no/altinn-rettigheter-proxy
+    url: https://arbeidsgiver.intern.nav.no/altinn-rettigheter-proxy/
   iaweb.service:
     code: 3403
     edition: 2


### PR DESCRIPTION
Fremtiden er her, og altinn-rettigheter-proxy kjører nå på GCP.

Tok meg friheten å deployet det til dev. Har testet at den treffer gcp-versjonen av altinn-proxyen i dev. Bare å merge for min del. altinn-rettigheter-proxy-klient har jo fallback hvis det oppstår problemer.