### PR TITLE
Optimalisere uthenting av sf statistikk fra in memory liste

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/snyk-oppdateringer-i-mai-2021'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/optimalisere-uthenting-av-sf-statistikk-fra-in-memory-liste'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/EksporteringRepository.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/EksporteringRepository.java
@@ -8,11 +8,8 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
-import java.sql.Connection;
-import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/EksporteringRepository.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/EksporteringRepository.java
@@ -66,6 +66,27 @@ public class EksporteringRepository {
         );
     }
 
+    public void batchOppdaterTilEksportert(
+            List<String> virksomheterSomSkalFlaggesSomEksportert,
+            ÅrstallOgKvartal årstallOgKvartal
+    ) {
+        SqlParameterSource parametre =
+                new MapSqlParameterSource()
+                        .addValue("årstall", årstallOgKvartal.getÅrstall())
+                        .addValue("kvartal", årstallOgKvartal.getKvartal())
+                        .addValue("orgnrListe", virksomheterSomSkalFlaggesSomEksportert)
+                        .addValue("eksportert", true)
+                        .addValue("oppdatert", LocalDateTime.now());
+
+        namedParameterJdbcTemplate.update(
+                "update eksport_per_kvartal set eksportert = :eksportert, oppdatert = :oppdatert " +
+                        "where arstall = :årstall " +
+                        "and kvartal = :kvartal " +
+                        "and orgnr in (:orgnrListe) ",
+                parametre
+        );
+    }
+
     @Async
     public void oppdaterTilEksportert(VirksomhetEksportPerKvartal virksomhetTilEksport) {
         SqlParameterSource parametre =

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/autoeksport/EksporteringService.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/autoeksport/EksporteringService.java
@@ -43,6 +43,7 @@ public class EksporteringService {
     private final KafkaService kafkaService;
     private final boolean erEksporteringAktivert;
 
+    public static final int OPPDATER_VIRKSOMHETER_SOM_ER_EKSPORTERT_BATCH_STØRRELSE = 1000;
     public static final int EKSPORT_BATCH_STØRRELSE = 10000;
 
     public EksporteringService(
@@ -231,7 +232,6 @@ public class EksporteringService {
                         antallSentTilEksport.getAndIncrement();
                         kafkaService.addUtsendingTilKafkaProcessingTime(startUtsendingProcess, stopUtsendingProcess);
 
-                        // synkrone kall til DB hver 1000 virksomheter prosessert
                         int antallVirksomhetertLagretSomEksportert =
                                 leggTilOrgnrIEksporterteVirksomheterListaOglagreIDbNårListaErFull(
                                         virksomhetMetadata.getOrgnr(),
@@ -274,7 +274,7 @@ public class EksporteringService {
     ) {
         virksomheterSomSkalFlaggesSomEksportert.add(orgnr);
 
-        if (virksomheterSomSkalFlaggesSomEksportert.size() == 1000) {
+        if (virksomheterSomSkalFlaggesSomEksportert.size() == OPPDATER_VIRKSOMHETER_SOM_ER_EKSPORTERT_BATCH_STØRRELSE) {
             return lagreEksporterteVirksomheterOgNullstillLista(årstallOgKvartal, virksomheterSomSkalFlaggesSomEksportert);
         } else {
             return 0;

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/autoeksport/EksporteringService.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/autoeksport/EksporteringService.java
@@ -122,6 +122,9 @@ public class EksporteringService {
         List<SykefraværsstatistikkVirksomhetUtenVarighet> sykefraværsstatistikkVirksomhetUtenVarighet =
                 sykefraværsstatistikkTilEksporteringRepository.hentSykefraværprosentAlleVirksomheter(årstallOgKvartal);
 
+        Map<String, SykefraværsstatistikkVirksomhetUtenVarighet> sykefraværsstatistikkVirksomhetUtenVarighetMap =
+                toMap(sykefraværsstatistikkVirksomhetUtenVarighet);
+
         SykefraværMedKategori landSykefravær = getSykefraværMedKategoriForLand(
                 årstallOgKvartal,
                 sykefraværsstatistikkLand
@@ -148,7 +151,7 @@ public class EksporteringService {
                             sykefraværsstatistikkSektor,
                             sykefraværsstatistikkNæring,
                             sykefraværsstatistikkNæring5Siffer,
-                            sykefraværsstatistikkVirksomhetUtenVarighet,
+                            sykefraværsstatistikkVirksomhetUtenVarighetMap,
                             landSykefravær,
                             antallEksportert,
                             virksomheterTilEksport.size()
@@ -174,13 +177,22 @@ public class EksporteringService {
         return antallEksportert.get();
     }
 
+    private Map<String, SykefraværsstatistikkVirksomhetUtenVarighet> toMap(List<SykefraværsstatistikkVirksomhetUtenVarighet> sykefraværsstatistikkVirksomhetUtenVarighet) {
+        Map<String, SykefraværsstatistikkVirksomhetUtenVarighet> map = new HashMap<>();
+        sykefraværsstatistikkVirksomhetUtenVarighet.forEach( sf -> {
+            map.put(sf.getOrgnr(), sf);
+        });
+
+        return map;
+    }
+
     protected void sendIBatch(
             List<VirksomhetMetadata> virksomheterMetadata,
             ÅrstallOgKvartal årstallOgKvartal,
             List<SykefraværsstatistikkSektor> sykefraværsstatistikkSektor,
             List<SykefraværsstatistikkNæring> sykefraværsstatistikkNæring,
             List<SykefraværsstatistikkNæring5Siffer> sykefraværsstatistikkNæring5Siffer,
-            List<SykefraværsstatistikkVirksomhetUtenVarighet> sykefraværsstatistikkVirksomhetUtenVarighet,
+            Map<String, SykefraværsstatistikkVirksomhetUtenVarighet> sykefraværsstatistikkVirksomhetUtenVarighet,
             SykefraværMedKategori landSykefravær,
             AtomicInteger antallEksportert,
             int antallTotaltStatistikk
@@ -341,6 +353,23 @@ public class EksporteringService {
                 sfStatistikk.getTapteDagsverk(),
                 sfStatistikk.getMuligeDagsverk(),
                 sfStatistikk.getAntallPersoner()
+        );
+    }
+
+    protected static VirksomhetSykefravær getVirksomhetSykefravær(
+            VirksomhetMetadata virksomhetMetadata,
+            Map<String, SykefraværsstatistikkVirksomhetUtenVarighet> sykefraværsstatistikkVirksomhetUtenVarighet
+    ) {
+        SykefraværsstatistikkVirksomhetUtenVarighet sfStatistikk =
+                sykefraværsstatistikkVirksomhetUtenVarighet.get(virksomhetMetadata.getOrgnr());
+
+        return new VirksomhetSykefravær(
+                virksomhetMetadata.getOrgnr(),
+                virksomhetMetadata.getNavn(),
+                new ÅrstallOgKvartal(virksomhetMetadata.getÅrstall(), virksomhetMetadata.getKvartal()),
+                sfStatistikk != null? sfStatistikk.getTapteDagsverk() : null,
+                sfStatistikk != null? sfStatistikk.getMuligeDagsverk() : null,
+                sfStatistikk != null? sfStatistikk.getAntallPersoner() : 0
         );
     }
 

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/autoeksport/EksporteringService.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/autoeksport/EksporteringService.java
@@ -249,6 +249,8 @@ public class EksporteringService {
         antallVirksomheterLagretSomEksportertIDb.addAndGet(antallRestendeOppdatert);
         int eksportertHittilNå = antallEksportert.addAndGet(antallSentTilEksport.get());
 
+        cleanUpEtterBatch();
+
         log.info(
                 String.format(
                         "Eksportert '%d' rader av '%d' totalt ('%d' oppdatert i DB)",
@@ -257,6 +259,11 @@ public class EksporteringService {
                         antallVirksomheterLagretSomEksportertIDb.get()
                 )
         );
+    }
+
+    private void cleanUpEtterBatch() {
+        eksporteringRepository.oppdaterAlleVirksomheterIEksportTabellSomErBekrreftetEksportert();
+        eksporteringRepository.slettVirksomheterBekreftetEksportert();
     }
 
     private int leggTilOrgnrIEksporterteVirksomheterListaOglagreIDbNårListaErFull(

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/autoeksport/EksporteringService.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/autoeksport/EksporteringService.java
@@ -230,6 +230,7 @@ public class EksporteringService {
                         long stopUtsendingProcess = System.nanoTime();
                         antallSentTilEksport.getAndIncrement();
                         kafkaService.addUtsendingTilKafkaProcessingTime(startUtsendingProcess, stopUtsendingProcess);
+
                         // synkrone kall til DB hver 1000 virksomheter prosessert
                         int antallVirksomhetertLagretSomEksportert =
                                 leggTilOrgnrIEksporterteVirksomheterListaOglagreIDbNårListaErFull(

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/config/KafkaConfig.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/config/KafkaConfig.java
@@ -15,14 +15,14 @@ class KafkaConfig {
 	@Bean
 	KafkaTemplate<String, String> kafkaTemplate(KafkaProperties kafkaProperties) {
 		KafkaTemplate<String, String> kafkaTemplate = new KafkaTemplate<>(
-				new DefaultKafkaProducerFactory<String, String>(kafkaProperties.asProperties())
+				new DefaultKafkaProducerFactory<>(kafkaProperties.asProperties())
 		);
 		kafkaTemplate.setProducerListener(getProducerListener());
 		return kafkaTemplate;
 	}
 
 	ProducerListener<String, String> getProducerListener() {
-		return new ProducerListener<String, String>() {
+		return new ProducerListener<>() {
 			@Override
 			public void onSuccess(ProducerRecord<String, String> producerRecord, RecordMetadata recordMetadata) {
 				log.debug(

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/config/KafkaProperties.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/config/KafkaProperties.java
@@ -39,7 +39,7 @@ public class KafkaProperties {
 	private final Integer deliveryTimeoutMs = 120000; // 2 min (default)
 	private final Integer requestTimeoutMs = 10000;
 	private final Integer lingerMs = 100;
-	private final Integer batchSize = 16384*100;
+	private final Integer batchSize = 16384*10; // størrelse av en melding er mellom 1000 bytes og 20K bytes (virksomhet med 70+ 5siffer næringskoder)
 	private final Integer maxInFlightRequestsPerConnection = 5; // default
 
 	public Map<String, Object> asProperties() {

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/config/KafkaProperties.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/config/KafkaProperties.java
@@ -35,8 +35,8 @@ public class KafkaProperties {
 	private final String clientId = "sykefravarsstatistikk-api";
 	private final String valueSerializerClass = StringSerializer.class.getName();
 	private final String keySerializerCLass = StringSerializer.class.getName();
-	private final Integer retries = Integer.MAX_VALUE;
-	private final Integer deliveryTimeoutMs = 11100;
+	private final Integer retries = 10;
+	private final Integer deliveryTimeoutMs = 60000;
 	private final Integer requestTimeoutMs = 10000;
 	private final Integer lingerMs = 100;
 	private final Integer batchSize = 16384*10;

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/config/KafkaProperties.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/config/KafkaProperties.java
@@ -36,10 +36,10 @@ public class KafkaProperties {
 	private final String valueSerializerClass = StringSerializer.class.getName();
 	private final String keySerializerCLass = StringSerializer.class.getName();
 	private final Integer retries = 10;
-	private final Integer deliveryTimeoutMs = 60000;
+	private final Integer deliveryTimeoutMs = 120000; // 2 min (default)
 	private final Integer requestTimeoutMs = 10000;
 	private final Integer lingerMs = 100;
-	private final Integer batchSize = 16384*10;
+	private final Integer batchSize = 16384*100;
 	private final Integer maxInFlightRequestsPerConnection = 5; // default
 
 	public Map<String, Object> asProperties() {

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/integrasjoner/kafka/KafkaService.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/integrasjoner/kafka/KafkaService.java
@@ -153,12 +153,12 @@ public class KafkaService {
         return kafkaUtsendingRapport.getRåDataVedDetaljertMåling();
     }
 
-    public void addProcessingTime(
-            long startUtsendingProcess,
-            long stopUtsendingProcess,
-            long startWriteToDB,
-            long stopWriteToDB
-    ) {
-        kafkaUtsendingRapport.addProcessingTime(startUtsendingProcess, stopUtsendingProcess, startWriteToDB, stopWriteToDB);
+    public void addUtsendingTilKafkaProcessingTime(long startUtsendingProcess, long stopUtsendingProcess) {
+        kafkaUtsendingRapport.addUtsendingTilKafkaProcessingTime(startUtsendingProcess, stopUtsendingProcess);
     }
+
+    public void addDBOppdateringProcessingTime(long startDBOppdateringProcess, long stopDBOppdateringProcess) {
+        kafkaUtsendingRapport.addDBOppdateringProcessingTime(startDBOppdateringProcess, stopDBOppdateringProcess);
+    }
+
 }

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/integrasjoner/kafka/KafkaUtsendingRapport.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/integrasjoner/kafka/KafkaUtsendingRapport.java
@@ -114,10 +114,11 @@ public class KafkaUtsendingRapport {
 
     public String getRåDataVedDetaljertMåling() {
         return String.format(
-                "Antall målet er: '%d', totaltTidUtsendingTilKafka er '%d', totaltTidOppdaterDB er '%d'",
+                "Antall målet er: '%d', totaltTidUtsendingTilKafka er '%d' (in millis), " +
+                        "totaltTidOppdaterDB er '%d' (in millis)",
                 antallUtsendigerMålet.get(),
-                totaltTidUtsendingTilKafka.get(),
-                totaltTidOppdaterDB.get()
+                totaltTidUtsendingTilKafka.get() / 1000,
+                totaltTidOppdaterDB.get() / 1000
         );
     }
 

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/integrasjoner/kafka/KafkaUtsendingRapport.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/integrasjoner/kafka/KafkaUtsendingRapport.java
@@ -117,8 +117,8 @@ public class KafkaUtsendingRapport {
                 "Antall målet er: '%d', totaltTidUtsendingTilKafka er '%d' (in millis), " +
                         "totaltTidOppdaterDB er '%d' (in millis)",
                 antallUtsendigerMålet.get(),
-                totaltTidUtsendingTilKafka.get() / 1000,
-                totaltTidOppdaterDB.get() / 1000
+                totaltTidUtsendingTilKafka.get() / 1000000,
+                totaltTidOppdaterDB.get() / 1000000
         );
     }
 

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/integrasjoner/kafka/KafkaUtsendingRapport.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/integrasjoner/kafka/KafkaUtsendingRapport.java
@@ -17,7 +17,8 @@ public class KafkaUtsendingRapport {
     private final List<String> meldinger;
     private final List<Orgnr> sentVirksomheter;
     private final List<Orgnr> ikkeSentVirksomheter;
-    private AtomicInteger antallMålet;
+    private AtomicInteger antallUtsendigerMålet;
+    private AtomicInteger antallDBOppdateringerMålet;
     private AtomicLong totaltTidUtsendingTilKafka;
     private AtomicLong totaltTidOppdaterDB;
     private int totalMeldingerTilUtsending;
@@ -31,7 +32,8 @@ public class KafkaUtsendingRapport {
         meldinger = new ArrayList<>();
         sentVirksomheter = new ArrayList<>();
         ikkeSentVirksomheter = new ArrayList<>();
-        antallMålet = new AtomicInteger();
+        antallUtsendigerMålet = new AtomicInteger();
+        antallDBOppdateringerMålet = new AtomicInteger();
         totaltTidUtsendingTilKafka = new AtomicLong();
         totaltTidOppdaterDB = new AtomicLong();
     }
@@ -44,7 +46,8 @@ public class KafkaUtsendingRapport {
         meldinger.clear();
         sentVirksomheter.clear();
         ikkeSentVirksomheter.clear();
-        antallMålet.set(0);
+        antallUtsendigerMålet.set(0);
+        antallDBOppdateringerMålet.set(0);
         totaltTidUtsendingTilKafka.set(0);
         totaltTidOppdaterDB.set(0);
     }
@@ -94,38 +97,43 @@ public class KafkaUtsendingRapport {
     }
 
     public long getSnittTidUtsendingTilKafka() {
-        if (antallMålet.get() == 0) {
+        if (antallUtsendigerMålet.get() == 0) {
             return 0;
         }
 
-        return totaltTidUtsendingTilKafka.get() / antallMålet.get();
+        return totaltTidUtsendingTilKafka.get() / antallUtsendigerMålet.get();
     }
 
     public long getSnittTidOppdateringIDB() {
-        if (antallMålet.get() == 0) {
+        if (antallDBOppdateringerMålet.get() == 0) {
             return 0;
         }
 
-        return totaltTidOppdaterDB.get() / antallMålet.get();
+        return totaltTidOppdaterDB.get() / antallDBOppdateringerMålet.get();
     }
 
     public String getRåDataVedDetaljertMåling() {
         return String.format(
                 "Antall målet er: '%d', totaltTidUtsendingTilKafka er '%d', totaltTidOppdaterDB er '%d'",
-                antallMålet.get(),
+                antallUtsendigerMålet.get(),
                 totaltTidUtsendingTilKafka.get(),
                 totaltTidOppdaterDB.get()
         );
     }
 
-    public void addProcessingTime(
+    public void addUtsendingTilKafkaProcessingTime(
             long startUtsendingProcess,
-            long stopUtsendingProcess,
-            long startWriteToDb,
-            long stoptWriteToDb
+            long stopUtsendingProcess
     ) {
-        antallMålet.incrementAndGet();
+        antallUtsendigerMålet.incrementAndGet();
         totaltTidUtsendingTilKafka.addAndGet(stopUtsendingProcess - startUtsendingProcess);
-        totaltTidOppdaterDB.addAndGet(stoptWriteToDb - startWriteToDb);
+    }
+
+    public void addDBOppdateringProcessingTime(
+            long startDBOppdateringProcess,
+            long stopDBOppdateringProcess
+            ) {
+        antallDBOppdateringerMålet.incrementAndGet();
+        totaltTidOppdaterDB.addAndGet(stopDBOppdateringProcess - startDBOppdateringProcess);
     }
 }

--- a/src/main/resources/db/migration/V21__virksomheter_bekreftet_eksportert.sql
+++ b/src/main/resources/db/migration/V21__virksomheter_bekreftet_eksportert.sql
@@ -1,0 +1,6 @@
+create table virksomheter_bekreftet_eksportert (
+    orgnr      varchar  not null primary key,
+    arstall    smallint not null,
+    kvartal    smallint not null,
+    opprettet  timestamp default current_timestamp
+);

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/TestUtils.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/TestUtils.java
@@ -22,4 +22,11 @@ public class TestUtils {
         jdbcTemplate.update("delete from sykefravar_statistikk_land", new MapSqlParameterSource());
         jdbcTemplate.update("delete from naring", new MapSqlParameterSource());
     }
+
+    public static void slettAllEksportDataFraDatabase(NamedParameterJdbcTemplate jdbcTemplate) {
+        jdbcTemplate.update("delete from virksomhet_metadata", new MapSqlParameterSource());
+        jdbcTemplate.update("delete from eksport_per_kvartal", new MapSqlParameterSource());
+        jdbcTemplate.update("delete from kafka_utsending_historikk", new MapSqlParameterSource());
+        jdbcTemplate.update("delete from virksomheter_bekreftet_eksportert", new MapSqlParameterSource());
+    }
 }

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/EksporteringRepositoryTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/EksporteringRepositoryTest.java
@@ -27,6 +27,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @DataJdbcTest
 class EksporteringRepositoryTest {
 
+    public static final Orgnr ORGNR_1 = new Orgnr(ORGNR_VIRKSOMHET_1);
+    public static final Orgnr ORGNR_2 = new Orgnr(ORGNR_VIRKSOMHET_2);
+    public static final Orgnr ORGNR_3 = new Orgnr(ORGNR_VIRKSOMHET_3);
+    public static final ÅrstallOgKvartal _2021_1 = new ÅrstallOgKvartal(2021, 1);
+
     @Autowired
     private NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -98,27 +103,6 @@ class EksporteringRepositoryTest {
     }
 
     @Test
-    void oppdater_med_oppdatert_dato() {
-        LocalDateTime testStartDato = LocalDateTime.now();
-        VirksomhetEksportPerKvartal virksomhetTilEksport = new VirksomhetEksportPerKvartal(
-                new Orgnr(ORGNR_VIRKSOMHET_1),
-                new ÅrstallOgKvartal(2020, 2),
-                false
-        );
-        opprettTestVirksomhetMetaData(2020, 2, ORGNR_VIRKSOMHET_1);
-        List<VirksomhetEksportPerKvartalMedDatoer> resultsBefore = hentAlleVirksomhetEksportPerKvartal();
-        assertEquals(false, resultsBefore.get(0).eksportert);
-
-        eksporteringRepository.oppdaterTilEksportert(virksomhetTilEksport);
-
-        List<VirksomhetEksportPerKvartalMedDatoer> results = hentAlleVirksomhetEksportPerKvartal();
-        assertEquals(1, results.size());
-        VirksomhetEksportPerKvartalMedDatoer actual = results.get(0);
-        assertEquals(true, actual.eksportert);
-        assertEquals(true, actual.oppdatert.isAfter(testStartDato));
-    }
-
-    @Test
     void batchOpprettVirksomheterBekreftetEksportert__opprett_i_batch() {
         List<String> virksomheterBekreftetEksportert = new ArrayList<>();
         virksomheterBekreftetEksportert.add(ORGNR_VIRKSOMHET_1);
@@ -138,30 +122,54 @@ class EksporteringRepositoryTest {
     }
 
     @Test
-    void batchOppdater_med_oppdatert_dato() {
+    void oppdaterVirksomheterIEksportTabell__oppdater_virksomheter_som_er_bekreftet_eksportert_og_returnerer_antall_oppdatert() {
         LocalDateTime testStartDato = LocalDateTime.now();
-        List<String> virksomheterSomSkalOppdateres = new ArrayList<>();
-        virksomheterSomSkalOppdateres.add(ORGNR_VIRKSOMHET_1);
-        virksomheterSomSkalOppdateres.add(ORGNR_VIRKSOMHET_2);
-        opprettTestVirksomhetMetaData(2020, 2, ORGNR_VIRKSOMHET_1);
-        opprettTestVirksomhetMetaData(2020, 2, ORGNR_VIRKSOMHET_2);
-        opprettTestVirksomhetMetaData(2020, 2, ORGNR_VIRKSOMHET_3);
-        List<VirksomhetEksportPerKvartalMedDatoer> resultsBefore = hentAlleVirksomhetEksportPerKvartal();
-        assertEquals(false, resultsBefore.get(0).eksportert);
-        assertEquals(false, resultsBefore.get(1).eksportert);
-        assertEquals(false, resultsBefore.get(2).eksportert);
+        createVirksomhetBekreftetEksportert(new VirksomhetBekreftetEksportert(ORGNR_1, _2021_1, testStartDato));
+        createVirksomhetBekreftetEksportert(new VirksomhetBekreftetEksportert(ORGNR_2, _2021_1, testStartDato));
 
-        eksporteringRepository.batchOppdaterTilEksportert(
-                virksomheterSomSkalOppdateres,
-                new ÅrstallOgKvartal(2020, 2)
+        createVirksomhetEksportPerKvartal(
+                new VirksomhetEksportPerKvartalMedDatoer(ORGNR_1, _2021_1, true, testStartDato, testStartDato)
+        );
+        createVirksomhetEksportPerKvartal(
+                new VirksomhetEksportPerKvartalMedDatoer(ORGNR_2, _2021_1, false, testStartDato, null)
+        );
+        createVirksomhetEksportPerKvartal(
+                new VirksomhetEksportPerKvartalMedDatoer(ORGNR_3, _2021_1, false, testStartDato, null)
         );
 
+        int antallOppdatert = eksporteringRepository.oppdaterAlleVirksomheterIEksportTabellSomErBekrreftetEksportert();
+
+        assertEquals(1, antallOppdatert);
         List<VirksomhetEksportPerKvartalMedDatoer> results = hentAlleVirksomhetEksportPerKvartal();
-        assertEquals(3, results.size());
-        assertVirksomhetEksportPerKvartal(results, ORGNR_VIRKSOMHET_1, true, testStartDato);
-        assertVirksomhetEksportPerKvartal(results, ORGNR_VIRKSOMHET_2, true, testStartDato);
-        assertVirksomhetEksportPerKvartal(results, ORGNR_VIRKSOMHET_3, false, null);
+        assertVirksomhetEksportPerKvartal(results, ORGNR_1.getVerdi(), true, testStartDato);
+        assertVirksomhetEksportPerKvartal(results, ORGNR_2.getVerdi(), true, testStartDato, true);
+        assertVirksomhetEksportPerKvartal(results, ORGNR_3.getVerdi(), false, testStartDato);
     }
+
+    @Test
+    void slettVirksomheterBekreftetEksportert__sletter_alle_rader_i_tabellen_og_returnerer_antall_slettet() {
+        createVirksomhetBekreftetEksportert(
+                new VirksomhetBekreftetEksportert(
+                        new Orgnr(ORGNR_VIRKSOMHET_1),
+                        new ÅrstallOgKvartal(2020, 1),
+                        LocalDateTime.now()
+                )
+        );
+        createVirksomhetBekreftetEksportert(
+                new VirksomhetBekreftetEksportert(
+                        new Orgnr(ORGNR_VIRKSOMHET_2),
+                        new ÅrstallOgKvartal(2020, 1),
+                        LocalDateTime.now()
+                )
+        );
+
+        int antallSlettet = eksporteringRepository.slettVirksomheterBekreftetEksportert();
+
+        assertEquals(2, antallSlettet);
+        List<VirksomhetEksportPerKvartalMedDatoer> results = hentAlleVirksomhetEksportPerKvartal();
+        assertEquals(0, hentAlleVirksomhetBekreftetEksportert().size());
+    }
+
 
     @Test
     void hentAntallIkkeEksportertRader__skal_retunere_riktig_tall() {
@@ -192,7 +200,17 @@ class EksporteringRepositoryTest {
             List<VirksomhetEksportPerKvartalMedDatoer> results,
             String orgnr,
             boolean expectedEksportert,
-            LocalDateTime oppdatertEtterDato
+            LocalDateTime oppdatertEtterDato) {
+
+        assertVirksomhetEksportPerKvartal(results, orgnr, expectedEksportert, oppdatertEtterDato, false);
+    }
+
+    private void assertVirksomhetEksportPerKvartal(
+            List<VirksomhetEksportPerKvartalMedDatoer> results,
+            String orgnr,
+            boolean expectedEksportert,
+            LocalDateTime oppdatertEtterDato,
+            boolean sjekkOppdatertDatoErEndret
     ) {
         VirksomhetEksportPerKvartalMedDatoer actual = results
                 .stream()
@@ -203,12 +221,13 @@ class EksporteringRepositoryTest {
                 .get();
         assertEquals(expectedEksportert, actual.eksportert);
 
-        if (expectedEksportert) {
-            assertEquals(true, actual.oppdatert.isAfter(oppdatertEtterDato));
-        } else {
+        if (!expectedEksportert) {
             assertNull(actual.oppdatert);
         }
 
+        if (sjekkOppdatertDatoErEndret) {
+            assertEquals(true, actual.oppdatert.isAfter(oppdatertEtterDato));
+        }
     }
 
     private void assertVirksomhetBekreftetEksportert(
@@ -256,6 +275,19 @@ class EksporteringRepositoryTest {
         return jdbcTemplate.update(
                 "insert into eksport_per_kvartal (orgnr, arstall, kvartal, eksportert, oppdatert) " +
                         "values (:orgnr, :årstall, :kvartal, :eksportert, :oppdatert)",
+                parametre);
+    }
+
+    private int createVirksomhetBekreftetEksportert(VirksomhetBekreftetEksportert virksomhet) {
+        MapSqlParameterSource parametre = new MapSqlParameterSource()
+                .addValue("orgnr", virksomhet.orgnr.getVerdi())
+                .addValue("årstall", virksomhet.årstallOgKvartal.getÅrstall())
+                .addValue("kvartal", virksomhet.årstallOgKvartal.getKvartal())
+                .addValue("opprettet", virksomhet.opprettet);
+
+        return jdbcTemplate.update(
+                "insert into virksomheter_bekreftet_eksportert (orgnr, arstall, kvartal, opprettet) " +
+                        "values (:orgnr, :årstall, :kvartal, :opprettet)",
                 parametre);
     }
 

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/EksporteringRepositoryTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/EksporteringRepositoryTest.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.*;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllEksportDataFraDatabase;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllStatistikkFraDatabase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -40,13 +41,13 @@ class EksporteringRepositoryTest {
     @BeforeEach
     void setUp() {
         eksporteringRepository = new EksporteringRepository(jdbcTemplate);
-        slettAllStatistikkFraDatabase(jdbcTemplate);
+        slettAllEksportDataFraDatabase(jdbcTemplate);
 
     }
 
     @AfterEach
     void tearDown() {
-        slettAllStatistikkFraDatabase(jdbcTemplate);
+        slettAllEksportDataFraDatabase(jdbcTemplate);
     }
 
 
@@ -100,6 +101,19 @@ class EksporteringRepositoryTest {
 
         oppdaterteRader = eksporteringRepository.opprettEksport(Collections.emptyList());
         assertEquals(0, oppdaterteRader);
+    }
+
+    @Test
+    void batchOpprettVirksomheterBekreftetEksportert__oppretter_ingenting_hvis_lista_er_tom() {
+        List<String> virksomheterBekreftetEksportert = new ArrayList<>();
+
+        eksporteringRepository.batchOpprettVirksomheterBekreftetEksportert(
+                virksomheterBekreftetEksportert,
+                new ÅrstallOgKvartal(2020, 2)
+        );
+
+        List<VirksomhetBekreftetEksportert> results = hentAlleVirksomhetBekreftetEksportert();
+        assertEquals(0, results.size());
     }
 
     @Test

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/integrasjoner/kafka/KafkaUtsendingRapportTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/integrasjoner/kafka/KafkaUtsendingRapportTest.java
@@ -11,8 +11,10 @@ class KafkaUtsendingRapportTest {
         KafkaUtsendingRapport rapport = new KafkaUtsendingRapport();
         rapport.reset(2);
 
-        rapport.addProcessingTime(500, 550, 8000, 8800);
-        rapport.addProcessingTime(1500, 1530, 2000, 3000);
+        rapport.addUtsendingTilKafkaProcessingTime(500, 550);
+        rapport.addDBOppdateringProcessingTime(8000, 8800);
+        rapport.addUtsendingTilKafkaProcessingTime(1500, 1530);
+        rapport.addDBOppdateringProcessingTime(2000, 3000);
 
         assertEquals(40, rapport.getSnittTidUtsendingTilKafka());
         assertEquals(900, rapport.getSnittTidOppdateringIDB());


### PR DESCRIPTION
Endringer i denne PR: 

- bruke en HashMap i stedet av en ArrayList for hente sykefraværsstatistikk til hver virksomhet (100 ganger raskere)
- fjerne kode som setter `eksportert` feltet til `true` i `eksport_per_kvartal` _working table_ (update mekanisme som var veldig kostbar)
- erstatte denne update mekanismen med utskriving til en ny tabell `virksomheter_bekreftet_eksportert`
- bruke data i `virksomheter_bekreftet_eksportert` for å sette `eksportert` feltet til `true` i `eksport_per_kvartal` når eksportering er ferdig (tar cirka 30 sek for å oppdatere 500.000 rader i en update)
- slette data i `virksomheter_bekreftet_eksportert` så tabellen er klar til neste eksportering

Oppnådd forbedringer: 
 - raskere utsending til Kafka (x100), tar ca 100 sek for å sende 500.000 meldinger
 - raskere oppdatering av de virksomhetene prosessert i eksporteringen (30 sek for hele batch)
 - DB er ferdig oppdatert (tabell `eksport_per_kvartal`) når eksportering er ferdig. Da er det klart til ny eksport.
 - Full eksportering av et kvartal tar cirka 2 minutter

Mulige forbedringer:
 - lagre data i `kafka_utsending_historikk` synkront og i batch av 1000 rader (tar forøvrig 5 min etter eksporteringen er ferdig for å lagre alle asynk kall til DB)