### PR TITLE
Oppdatering avhengigheter juni 2021

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/optimalisere-uthenting-av-sf-statistikk-fra-in-memory-liste'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/oppdatering-avhengigheter-juni-2021'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.5.8</version>
+            <version>1.5.9</version>
         </dependency>
 
 
@@ -124,20 +124,20 @@
         <dependency>
             <groupId>no.nav.common</groupId>
             <artifactId>log</artifactId>
-            <version>2.2021.05.03_09.21-91f2fc8f059e</version>
+            <version>2.2021.06.04_09.13-e0f33e1571bc</version>
         </dependency>
 
         <!-- Prometheus -->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.6.6</version>
+            <version>1.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.6.6</version>
+            <version>1.7.0</version>
         </dependency>
 
         <!-- OIDC Support -->
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>8.21</version>
+            <version>8.21.1</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>
@@ -175,19 +175,19 @@
         <dependency>
             <groupId>no.finn.unleash</groupId>
             <artifactId>unleash-client-java</artifactId>
-            <version>4.2.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <!-- Shedlock -->
         <dependency>
             <groupId>net.javacrumbs.shedlock</groupId>
             <artifactId>shedlock-spring</artifactId>
-            <version>4.23.0</version>
+            <version>4.24.0</version>
         </dependency>
         <dependency>
             <groupId>net.javacrumbs.shedlock</groupId>
             <artifactId>shedlock-provider-jdbc-template</artifactId>
-            <version>4.23.0</version>
+            <version>4.24.0</version>
         </dependency>
 
         <!-- Test -->
@@ -199,7 +199,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.9.0</version>
+            <version>3.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <oidc-support.version>1.3.7</oidc-support.version>
         <altinn-rettigheter-proxy-klient.version>2.0.1</altinn-rettigheter-proxy-klient.version>
+        <micrometer.version>1.7.0</micrometer.version>
+        <prometheus.version>0.10.0</prometheus.version>
         <java.version>11</java.version>
     </properties>
 
@@ -131,13 +133,18 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.7.0</version>
+            <version>${micrometer.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.7.0</version>
+            <version>${micrometer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_logback</artifactId>
+            <version>${prometheus.version}</version>
         </dependency>
 
         <!-- OIDC Support -->


### PR DESCRIPTION
Avventer med å oppgradere Spring fra `2.4.5` til `2.5.0` etter at det skapte problemer med `fasterxml.jackson-core` bibliotek
Resten er oppdatert og testet i `q` miljø