### PR TITLE
Oppdatere avhengigheter august 2021

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/oppdatere-avh-juli-21'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/oppdatere-avhengigheter-august-2021'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.5</version>
+        <version>2.5.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
-        <!-- dependencies -->
+        <!-- versjon til avhengigheter -->
         <oidc-support.version>1.3.8</oidc-support.version>
         <altinn-rettigheter-proxy-klient.version>2.0.2</altinn-rettigheter-proxy-klient.version>
         <micrometer.version>1.7.2</micrometer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <!-- dependencies -->
         <oidc-support.version>1.3.8</oidc-support.version>
         <altinn-rettigheter-proxy-klient.version>2.0.2</altinn-rettigheter-proxy-klient.version>
-        <micrometer.version>1.7.0</micrometer.version>
+        <micrometer.version>1.7.1</micrometer.version>
         <prometheus.version>0.11.0</prometheus.version>
         <mockito-junit-jupiter.version>3.11.2</mockito-junit-jupiter.version>
         <wiremock.version>2.27.2</wiremock.version>
@@ -33,7 +33,7 @@
         <unleash.version>4.4.0</unleash.version>
         <no.nav.common-log.version>2.2021.07.01_07.04-4e699536ceb1</no.nav.common-log.version>
         <net.minidev.json-smart.version>2.4.7</net.minidev.json-smart.version>
-        <com.nimbusds.nimbus-jose-jwt.version>8.22</com.nimbusds.nimbus-jose-jwt.version>
+        <com.nimbusds.nimbus-jose-jwt.version>8.22.1</com.nimbusds.nimbus-jose-jwt.version>
         <com.papertrailapp.logback-syslog4j.version>1.0.0</com.papertrailapp.logback-syslog4j.version>
         <org.springdoc.springdoc-openapi-ui.version>1.5.10</org.springdoc.springdoc-openapi-ui.version>
         <no.nav.vault-jdbc.version>1.3.7</no.nav.vault-jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <java.version>11</java.version>
         <!-- dependencies -->
         <oidc-support.version>1.3.8</oidc-support.version>
-        <altinn-rettigheter-proxy-klient.version>2.0.1</altinn-rettigheter-proxy-klient.version>
+        <altinn-rettigheter-proxy-klient.version>2.0.2</altinn-rettigheter-proxy-klient.version>
         <micrometer.version>1.7.0</micrometer.version>
         <prometheus.version>0.11.0</prometheus.version>
         <mockito-junit-jupiter.version>3.11.2</mockito-junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.2</version>
+        <version>2.4.9</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>8.21.1</version>
+            <version>8.22</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,24 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>11</java.version>
+        <!-- dependencies -->
         <oidc-support.version>1.3.8</oidc-support.version>
         <altinn-rettigheter-proxy-klient.version>2.0.1</altinn-rettigheter-proxy-klient.version>
         <micrometer.version>1.7.0</micrometer.version>
         <prometheus.version>0.11.0</prometheus.version>
-        <java.version>11</java.version>
+        <mockito-junit-jupiter.version>3.11.2</mockito-junit-jupiter.version>
+        <wiremock.version>2.27.2</wiremock.version>
+        <shedlock.version>4.25.0</shedlock.version>
+        <unleash.version>4.4.0</unleash.version>
+        <no.nav.common-log.version>2.2021.07.01_07.04-4e699536ceb1</no.nav.common-log.version>
+        <net.minidev.json-smart.version>2.4.7</net.minidev.json-smart.version>
+        <com.nimbusds.nimbus-jose-jwt.version>8.22</com.nimbusds.nimbus-jose-jwt.version>
+        <com.papertrailapp.logback-syslog4j.version>1.0.0</com.papertrailapp.logback-syslog4j.version>
+        <org.springdoc.springdoc-openapi-ui.version>1.5.9</org.springdoc.springdoc-openapi-ui.version>
+        <no.nav.vault-jdbc.version>1.3.7</no.nav.vault-jdbc.version>
+        <com.oracle.ojdbc.ojdbc8.version>19.3.0.0</com.oracle.ojdbc.ojdbc8.version>
+        <com.h2database.h2.version>1.4.200</com.h2database.h2.version>
     </properties>
 
     <dependencies>
@@ -57,8 +70,6 @@
             <scope>test</scope>
         </dependency>
 
-
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
@@ -81,7 +92,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.200</version>
+            <version>${com.h2database.h2.version}</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -97,18 +108,18 @@
         <dependency>
             <groupId>com.oracle.ojdbc</groupId>
             <artifactId>ojdbc8</artifactId>
-            <version>19.3.0.0</version>
+            <version>${com.oracle.ojdbc.ojdbc8.version}</version>
         </dependency>
         <dependency>
             <groupId>no.nav</groupId>
             <artifactId>vault-jdbc</artifactId>
-            <version>1.3.7</version>
+            <version>${no.nav.vault-jdbc.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.5.9</version>
+            <version>${org.springdoc.springdoc-openapi-ui.version}</version>
         </dependency>
 
 
@@ -121,12 +132,12 @@
         <dependency>
             <groupId>com.papertrailapp</groupId>
             <artifactId>logback-syslog4j</artifactId>
-            <version>1.0.0</version>
+            <version>${com.papertrailapp.logback-syslog4j.version}</version>
         </dependency>
         <dependency>
             <groupId>no.nav.common</groupId>
             <artifactId>log</artifactId>
-            <version>2.2021.07.01_07.04-4e699536ceb1</version>
+            <version>${no.nav.common-log.version}</version>
         </dependency>
 
         <!-- Prometheus -->
@@ -164,12 +175,12 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>8.22</version>
+            <version>${com.nimbusds.nimbus-jose-jwt.version}</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>2.4.7</version>
+            <version>${net.minidev.json-smart.version}</version>
         </dependency>
 
 
@@ -182,31 +193,31 @@
         <dependency>
             <groupId>no.finn.unleash</groupId>
             <artifactId>unleash-client-java</artifactId>
-            <version>4.4.0</version>
+            <version>${unleash.version}</version>
         </dependency>
 
         <!-- Shedlock -->
         <dependency>
             <groupId>net.javacrumbs.shedlock</groupId>
             <artifactId>shedlock-spring</artifactId>
-            <version>4.25.0</version>
+            <version>${shedlock.version}</version>
         </dependency>
         <dependency>
             <groupId>net.javacrumbs.shedlock</groupId>
             <artifactId>shedlock-provider-jdbc-template</artifactId>
-            <version>4.25.0</version>
+            <version>${shedlock.version}</version>
         </dependency>
 
         <!-- Test -->
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.27.2</version>
+            <version>${wiremock.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.11.2</version>
+            <version>${mockito-junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <!-- dependencies -->
         <oidc-support.version>1.3.8</oidc-support.version>
         <altinn-rettigheter-proxy-klient.version>2.0.2</altinn-rettigheter-proxy-klient.version>
-        <micrometer.version>1.7.1</micrometer.version>
+        <micrometer.version>1.7.2</micrometer.version>
         <prometheus.version>0.11.0</prometheus.version>
         <mockito-junit-jupiter.version>3.11.2</mockito-junit-jupiter.version>
         <wiremock.version>2.27.2</wiremock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <net.minidev.json-smart.version>2.4.7</net.minidev.json-smart.version>
         <com.nimbusds.nimbus-jose-jwt.version>8.22</com.nimbusds.nimbus-jose-jwt.version>
         <com.papertrailapp.logback-syslog4j.version>1.0.0</com.papertrailapp.logback-syslog4j.version>
-        <org.springdoc.springdoc-openapi-ui.version>1.5.9</org.springdoc.springdoc-openapi-ui.version>
+        <org.springdoc.springdoc-openapi-ui.version>1.5.10</org.springdoc.springdoc-openapi-ui.version>
         <no.nav.vault-jdbc.version>1.3.7</no.nav.vault-jdbc.version>
         <com.oracle.ojdbc.ojdbc8.version>19.3.0.0</com.oracle.ojdbc.ojdbc8.version>
         <com.h2database.h2.version>1.4.200</com.h2database.h2.version>


### PR DESCRIPTION
Oppdaterte følgende avhengigheter: 
 - spring-boot-starter-parent [2.4.5 -> 2.4.9]
 - altinn-rettigheter-proxy-klient [2.0.1 -> 2.0.2]
 - micrometer [1.7.0 -> 1.7.2]
 - nimbus-jose-jwt [8.21.1 -> 8.22.1]
 - springdoc-openapi-ui [1.5.9 -> 1.5.10]
 
Dvs at nåværende Snyk PRs kan lukkes uten merge

Utsatt 
 - spring-boot-starter-parent [2.4.9 -> 2.5.2] medfører problemer med deploy 