### PR TITLE
Oppgraderinger desember 2021

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/oppgrader-log4j-api'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/oppgraderinger-desember-2021'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Kjør container
 ## Grafisk fremstilling av API-ene (swagger-ui)
 API-et kan sees og testes på: 
  * Lokalt: `http://localhost:8080/sykefravarsstatistikk-api/swagger-ui/index.html` 
- * På server: `{host}/sykefravarsstatistikk-api/swagger-ui/index.html?url=/v3/api-docs/`
+ * På server:
+   - `{host}/sykefravarsstatistikk-api/swagger-ui/index.html?configUrl=/sykefravarsstatistikk-api/v3/api-docs/swagger-config#/`
+   - `{host}/sykefravarsstatistikk-api/swagger-ui/index.html` og lim inn `/sykefravarsstatistikk-api/v3/api-docs` i __Explore__ søkefelt
 
 ---------
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Kjør container
 Åpne H2-konsollen på `http://localhost:8080/sykefravarsstatistikk-api/h2` og fyll inn det som står under `applikasjon.datasource` i `application.yaml`.
 
 ## Grafisk fremstilling av API-ene (swagger-ui)
-API-et kan sees og testes på `http://localhost:8080/sykefravarsstatistikk-api/swagger-ui.html`
+API-et kan sees og testes på: 
+ * Lokalt: `http://localhost:8080/sykefravarsstatistikk-api/swagger-ui/index.html` 
+ * På server: `{host}/sykefravarsstatistikk-api/swagger-ui/index.html?url=/v3/api-docs/`
 
 ---------
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <prometheus.version>0.12.0</prometheus.version>
         <mockito-junit-jupiter.version>3.11.2</mockito-junit-jupiter.version>
         <wiremock.version>2.27.2</wiremock.version>
-        <shedlock.version>4.28.0</shedlock.version>
+        <shedlock.version>4.30.0</shedlock.version>
         <unleash.version>4.4.0</unleash.version>
         <no.nav.common-log.version>2.2021.09.17_07.09-67428a6422cc</no.nav.common-log.version>
         <net.minidev.json-smart.version>2.4.7</net.minidev.json-smart.version>

--- a/pom.xml
+++ b/pom.xml
@@ -145,17 +145,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-to-slf4j</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <prometheus.version>0.12.0</prometheus.version>
         <mockito-junit-jupiter.version>3.11.2</mockito-junit-jupiter.version>
         <wiremock.version>2.27.2</wiremock.version>
-        <shedlock.version>4.27.0</shedlock.version>
+        <shedlock.version>4.28.0</shedlock.version>
         <unleash.version>4.4.0</unleash.version>
         <no.nav.common-log.version>2.2021.09.17_07.09-67428a6422cc</no.nav.common-log.version>
         <net.minidev.json-smart.version>2.4.7</net.minidev.json-smart.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <shedlock.shedlock-provider-jdbc-template.version>4.29.0</shedlock.shedlock-provider-jdbc-template.version>
         <shedlock.version>4.30.0</shedlock.version>
         <unleash.version>4.4.1</unleash.version>
-        <no.nav.common-log.version>2.2021.09.17_07.09-67428a6422cc</no.nav.common-log.version>
+        <no.nav.common-log.version>2.2021.11.15_14.58-d7a174cfb6a8</no.nav.common-log.version>
         <net.minidev.json-smart.version>2.4.7</net.minidev.json-smart.version>
         <com.nimbusds.nimbus-jose-jwt.version>8.23</com.nimbusds.nimbus-jose-jwt.version>
         <com.papertrailapp.logback-syslog4j.version>1.0.0</com.papertrailapp.logback-syslog4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <net.minidev.json-smart.version>2.4.7</net.minidev.json-smart.version>
         <com.nimbusds.nimbus-jose-jwt.version>8.23</com.nimbusds.nimbus-jose-jwt.version>
         <com.papertrailapp.logback-syslog4j.version>1.0.0</com.papertrailapp.logback-syslog4j.version>
-        <org.springdoc.springdoc-openapi-ui.version>1.6.0</org.springdoc.springdoc-openapi-ui.version>
+        <org.springdoc.springdoc-openapi-ui.version>1.6.1</org.springdoc.springdoc-openapi-ui.version>
         <no.nav.vault-jdbc.version>1.3.9</no.nav.vault-jdbc.version>
         <com.oracle.ojdbc.ojdbc8.version>19.3.0.0</com.oracle.ojdbc.ojdbc8.version>
         <com.h2database.h2.version>2.0.202</com.h2database.h2.version>
@@ -124,7 +124,11 @@
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>${org.springdoc.springdoc-openapi-ui.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-security</artifactId>
+            <version>${org.springdoc.springdoc-openapi-ui.version}</version>
+        </dependency>
 
         <!-- Logging -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <java.version>11</java.version>
         <!-- versjon til avhengigheter -->
         <io-vavr.version>0.10.4</io-vavr.version>
-        <oidc-support.version>1.3.8</oidc-support.version>
+        <oidc-support.version>1.3.9</oidc-support.version>
         <altinn-rettigheter-proxy-klient.version>2.0.6-rc</altinn-rettigheter-proxy-klient.version>
         <micrometer.version>1.7.4</micrometer.version>
         <prometheus.version>0.12.0</prometheus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <prometheus.version>0.12.0</prometheus.version>
         <mockito-junit-jupiter.version>3.11.2</mockito-junit-jupiter.version>
         <wiremock.version>2.27.2</wiremock.version>
+        <shedlock.shedlock-provider-jdbc-template.version>4.29.0</shedlock.shedlock-provider-jdbc-template.version>
         <shedlock.version>4.30.0</shedlock.version>
         <unleash.version>4.4.0</unleash.version>
         <no.nav.common-log.version>2.2021.09.17_07.09-67428a6422cc</no.nav.common-log.version>
@@ -39,7 +40,8 @@
         <org.springdoc.springdoc-openapi-ui.version>1.5.11</org.springdoc.springdoc-openapi-ui.version>
         <no.nav.vault-jdbc.version>1.3.9</no.nav.vault-jdbc.version>
         <com.oracle.ojdbc.ojdbc8.version>19.3.0.0</com.oracle.ojdbc.ojdbc8.version>
-        <com.h2database.h2.version>1.4.200</com.h2database.h2.version>
+        <com.h2database.h2.version>2.0.202</com.h2database.h2.version>
+        <org.flywaydb.version>8.2.2</org.flywaydb.version>
     </properties>
     <dependencies>
         <dependency>
@@ -99,6 +101,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
+            <version>${org.flywaydb.version}</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -221,7 +224,7 @@
         <dependency>
             <groupId>net.javacrumbs.shedlock</groupId>
             <artifactId>shedlock-provider-jdbc-template</artifactId>
-            <version>${shedlock.version}</version>
+            <version>${shedlock.shedlock-provider-jdbc-template.version}</version>
         </dependency>
 
         <!-- Utils -->

--- a/pom.xml
+++ b/pom.xml
@@ -26,18 +26,18 @@
         <io-vavr.version>0.10.4</io-vavr.version>
         <oidc-support.version>1.3.9</oidc-support.version>
         <altinn-rettigheter-proxy-klient.version>2.0.6-rc</altinn-rettigheter-proxy-klient.version>
-        <micrometer.version>1.7.4</micrometer.version>
+        <micrometer.version>1.8.0</micrometer.version>
         <prometheus.version>0.12.0</prometheus.version>
         <mockito-junit-jupiter.version>3.11.2</mockito-junit-jupiter.version>
         <wiremock.version>2.27.2</wiremock.version>
         <shedlock.shedlock-provider-jdbc-template.version>4.29.0</shedlock.shedlock-provider-jdbc-template.version>
         <shedlock.version>4.30.0</shedlock.version>
-        <unleash.version>4.4.0</unleash.version>
+        <unleash.version>4.4.1</unleash.version>
         <no.nav.common-log.version>2.2021.09.17_07.09-67428a6422cc</no.nav.common-log.version>
         <net.minidev.json-smart.version>2.4.7</net.minidev.json-smart.version>
         <com.nimbusds.nimbus-jose-jwt.version>8.23</com.nimbusds.nimbus-jose-jwt.version>
         <com.papertrailapp.logback-syslog4j.version>1.0.0</com.papertrailapp.logback-syslog4j.version>
-        <org.springdoc.springdoc-openapi-ui.version>1.5.11</org.springdoc.springdoc-openapi-ui.version>
+        <org.springdoc.springdoc-openapi-ui.version>1.6.0</org.springdoc.springdoc-openapi-ui.version>
         <no.nav.vault-jdbc.version>1.3.9</no.nav.vault-jdbc.version>
         <com.oracle.ojdbc.ojdbc8.version>19.3.0.0</com.oracle.ojdbc.ojdbc8.version>
         <com.h2database.h2.version>2.0.202</com.h2database.h2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,11 +124,6 @@
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>${org.springdoc.springdoc-openapi-ui.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-security</artifactId>
-            <version>${org.springdoc.springdoc-openapi-ui.version}</version>
-        </dependency>
 
         <!-- Logging -->
         <dependency>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,7 @@
 server.servlet.context-path: /sykefravarsstatistikk-api
+springdoc:
+  swagger-ui:
+    disable-swagger-default-url: true
 
 management.endpoints.web:
   exposure.include: info, health, metrics, prometheus

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,7 @@ springdoc:
   swagger-ui:
     disable-swagger-default-url: true
     validatorUrl: none
+    url: /swagger-ui/index.html?url=/v3/api-docs/
 
 management.endpoints.web:
   exposure.include: info, health, metrics, prometheus

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,7 @@ server.servlet.context-path: /sykefravarsstatistikk-api
 springdoc:
   swagger-ui:
     disable-swagger-default-url: true
+    validatorUrl: none
 
 management.endpoints.web:
   exposure.include: info, health, metrics, prometheus

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,13 +56,13 @@ statistikk.importering.aktivert: true
 statistikk.eksportering.aktivert: true
 
 applikasjon.datasource:
-  url: jdbc:h2:mem:test
+  url: jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
   username: SA
   password:
   driver-class-name: org.h2.Driver
 
 datavarehus.datasource:
-  url: jdbc:h2:mem:test
+  url: jdbc:h2:mem:test;MODE=Oracle;DB_CLOSE_DELAY=-1
   username: SA
   password:
   driver-class-name: org.h2.Driver
@@ -86,13 +86,13 @@ spring:
     locations: classpath:/db/migration,classpath:/db/test-datavarehus
 
 applikasjon.datasource:
-  url: jdbc:h2:mem:test
+  url: jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
   username: SA
   password:
   driver-class-name: org.h2.Driver
 
 datavarehus.datasource:
-  url: jdbc:h2:mem:test
+  url: jdbc:h2:mem:test;MODE=Oracle;DB_CLOSE_DELAY=-1
   username: SA
   password:
   driver-class-name: org.h2.Driver

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/AmendPrimaryKeyForH2Extension.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/AmendPrimaryKeyForH2Extension.java
@@ -1,0 +1,27 @@
+package no.nav.arbeidsgiver.sykefravarsstatistikk.api;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
+
+public class AmendPrimaryKeyForH2Extension implements BeforeAllCallback {
+
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        NamedParameterJdbcTemplate namedParameterJdbcTemplate =
+                SpringExtension.getApplicationContext(extensionContext).getBean(NamedParameterJdbcTemplate.class);
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "sykefravar_statistikk_land");
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "sykefravar_statistikk_naring");
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "sykefravar_statistikk_naring5siffer");
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "sykefravar_statistikk_naring_med_varighet");
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "sykefravar_statistikk_sektor");
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "sykefravar_statistikk_virksomhet");
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "sykefravar_statistikk_virksomhet_med_gradering");
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "virksomhet_metadata");
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "virksomhet_metadata_naring_kode_5siffer");
+    }
+}

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/TestUtils.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/TestUtils.java
@@ -5,6 +5,25 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 public class TestUtils {
 
+    /**
+     * H2 DB og PostgreSQL har forskjellige syntax for ID (primary key)
+     * H2 DB bruker 'bigint auto_increment' hvor PostgreSQL bruker 'serial'
+     * Denne metoden endrer feltet ID ut i fra migreringsscript slik at H2 klarer å auto-increment feltet ID ved 'insert'
+     * OBS: dette gjelder ikke applikasjon når den kjører lokalt: da er H2 DB startet med dialect PostgreSQL
+     */
+    public static void setAutoincrementPrimaryKeyForH2Db(
+            NamedParameterJdbcTemplate namedParameterJdbcTemplate,
+            String tabell
+    ) {
+        namedParameterJdbcTemplate.getJdbcTemplate().execute(String.format("alter table %s drop column id", tabell));
+        namedParameterJdbcTemplate.getJdbcTemplate().execute(
+                String.format(
+                        "alter table %s add id bigint auto_increment",
+                        tabell
+                )
+        );
+    }
+
     public static MapSqlParameterSource parametreForStatistikk(int årstall, int kvartal, int antallPersoner, int tapteDagsverk, int muligeDagsverk) {
         return new MapSqlParameterSource()
                 .addValue("arstall", årstall)

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/TestUtils.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/TestUtils.java
@@ -5,21 +5,25 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 public class TestUtils {
 
+    public static final String ID = "id";
+
     /**
      * H2 DB og PostgreSQL har forskjellige syntax for ID (primary key)
      * H2 DB bruker 'bigint auto_increment' hvor PostgreSQL bruker 'serial'
      * Denne metoden endrer feltet ID ut i fra migreringsscript slik at H2 klarer å auto-increment feltet ID ved 'insert'
-     * OBS: dette gjelder ikke applikasjon når den kjører lokalt: da er H2 DB startet med dialect PostgreSQL
+     * OBS: dette gjelder kun tester og ikke applikasjon når den kjører lokalt: da er H2 DB startet med dialect PostgreSQL
      */
     public static void setAutoincrementPrimaryKeyForH2Db(
             NamedParameterJdbcTemplate namedParameterJdbcTemplate,
             String tabell
     ) {
-        namedParameterJdbcTemplate.getJdbcTemplate().execute(String.format("alter table %s drop column id", tabell));
+
+        namedParameterJdbcTemplate.getJdbcTemplate().execute(String.format("alter table %s drop column %s", tabell, ID));
         namedParameterJdbcTemplate.getJdbcTemplate().execute(
                 String.format(
-                        "alter table %s add id bigint auto_increment",
-                        tabell
+                        "alter table %s add %s bigint auto_increment",
+                        tabell,
+                        ID
                 )
         );
     }

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/EksporteringRepositoryTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/EksporteringRepositoryTest.java
@@ -17,9 +17,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.*;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.ORGNR_VIRKSOMHET_1;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.ORGNR_VIRKSOMHET_2;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.ORGNR_VIRKSOMHET_3;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllEksportDataFraDatabase;
-import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllStatistikkFraDatabase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,7 +44,7 @@ class EksporteringRepositoryTest {
     void setUp() {
         eksporteringRepository = new EksporteringRepository(jdbcTemplate);
         slettAllEksportDataFraDatabase(jdbcTemplate);
-
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "eksport_per_kvartal");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/SykefraværsstatistikkTilEksporteringRepositoryTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/SykefraværsstatistikkTilEksporteringRepositoryTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.AssertUtils.assertBigDecimalIsEqual;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllStatistikkFraDatabase;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -50,6 +51,11 @@ class SykefraværsstatistikkTilEksporteringRepositoryTest {
     void setUp() {
         slettAllStatistikkFraDatabase(jdbcTemplate);
         repository = new SykefraværsstatistikkTilEksporteringRepository(jdbcTemplate);
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_land");
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_naring");
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_sektor");
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_naring5siffer");
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_virksomhet");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/SykefraværsstatistikkTilEksporteringRepositoryTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/SykefraværsstatistikkTilEksporteringRepositoryTest.java
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.eksportering;
 
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.AmendPrimaryKeyForH2Extension;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Næring;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Næringskode5Siffer;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Sektor;
@@ -13,6 +14,7 @@ import no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.Sykefraværssta
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -24,13 +26,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.AssertUtils.assertBigDecimalIsEqual;
-import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllStatistikkFraDatabase;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ActiveProfiles("db-test")
 @DataJdbcTest
+@ExtendWith(AmendPrimaryKeyForH2Extension.class)
 class SykefraværsstatistikkTilEksporteringRepositoryTest {
 
     @Autowired
@@ -51,11 +53,6 @@ class SykefraværsstatistikkTilEksporteringRepositoryTest {
     void setUp() {
         slettAllStatistikkFraDatabase(jdbcTemplate);
         repository = new SykefraværsstatistikkTilEksporteringRepository(jdbcTemplate);
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_land");
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_naring");
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_sektor");
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_naring5siffer");
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_virksomhet");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/VirksomhetMetadataRepositoryJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/VirksomhetMetadataRepositoryJdbcTest.java
@@ -1,10 +1,12 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.eksportering;
 
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.AmendPrimaryKeyForH2Extension;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Orgnr;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.ÅrstallOgKvartal;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -14,13 +16,17 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.Arrays;
 import java.util.List;
 
-import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.*;
-import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.NÆRINGSKODE_2SIFFER;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.ORGNR_VIRKSOMHET_1;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.ORGNR_VIRKSOMHET_2;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.ORGNR_VIRKSOMHET_3;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.SEKTOR;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.DatavarehusRepository.RECTYPE_FOR_VIRKSOMHET;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("db-test")
 @DataJdbcTest
+@ExtendWith(AmendPrimaryKeyForH2Extension.class)
 class VirksomhetMetadataRepositoryJdbcTest {
 
     @Autowired
@@ -32,8 +38,6 @@ class VirksomhetMetadataRepositoryJdbcTest {
     public void setUp() {
         repository = new VirksomhetMetadataRepository(namedParameterJdbcTemplate);
         cleanUpTestDb(namedParameterJdbcTemplate);
-        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "virksomhet_metadata");
-        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "virksomhet_metadata_naring_kode_5siffer");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/VirksomhetMetadataRepositoryJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/eksportering/VirksomhetMetadataRepositoryJdbcTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.*;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.DatavarehusRepository.RECTYPE_FOR_VIRKSOMHET;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +32,8 @@ class VirksomhetMetadataRepositoryJdbcTest {
     public void setUp() {
         repository = new VirksomhetMetadataRepository(namedParameterJdbcTemplate);
         cleanUpTestDb(namedParameterJdbcTemplate);
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "virksomhet_metadata");
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "virksomhet_metadata_naring_kode_5siffer");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/autoimport/StatistikkRepositoryJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/autoimport/StatistikkRepositoryJdbcTest.java
@@ -30,6 +30,7 @@ import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.NÆRINGSKOD
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.NÆRINGSKODE_5SIFFER;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.ORGNR_VIRKSOMHET_1;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.parametreForStatistikk;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllStatistikkFraDatabase;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.DatavarehusRepository.RECTYPE_FOR_VIRKSOMHET;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.statistikk.StatistikkRepository.INSERT_BATCH_STØRRELSE;
@@ -49,6 +50,10 @@ public class StatistikkRepositoryJdbcTest {
     public void setUp() {
         statistikkRepository = new StatistikkRepository(jdbcTemplate);
         slettAllStatistikkFraDatabase(jdbcTemplate);
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_virksomhet_med_gradering");
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_land");
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_virksomhet");
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_naring_med_varighet");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/autoimport/StatistikkRepositoryJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/autoimport/StatistikkRepositoryJdbcTest.java
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport;
 
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.AmendPrimaryKeyForH2Extension;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.ÅrstallOgKvartal;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.Statistikkilde;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.SykefraværsstatistikkNæringMedVarighet;
@@ -30,7 +31,6 @@ import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.NÆRINGSKOD
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.NÆRINGSKODE_5SIFFER;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.ORGNR_VIRKSOMHET_1;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.parametreForStatistikk;
-import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllStatistikkFraDatabase;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.DatavarehusRepository.RECTYPE_FOR_VIRKSOMHET;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.statistikk.StatistikkRepository.INSERT_BATCH_STØRRELSE;
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 @ActiveProfiles("db-test")
 @ExtendWith(MockitoExtension.class)
 @DataJdbcTest
+@ExtendWith(AmendPrimaryKeyForH2Extension.class)
 public class StatistikkRepositoryJdbcTest {
 
     @Autowired
@@ -50,10 +51,6 @@ public class StatistikkRepositoryJdbcTest {
     public void setUp() {
         statistikkRepository = new StatistikkRepository(jdbcTemplate);
         slettAllStatistikkFraDatabase(jdbcTemplate);
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_virksomhet_med_gradering");
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_land");
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_virksomhet");
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_naring_med_varighet");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkLandUtilsJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkLandUtilsJdbcTest.java
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.provisjonering.importering.integrasjon.utils;
 
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.AmendPrimaryKeyForH2Extension;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.ÅrstallOgKvartal;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.SykefraværsstatistikkLand;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.statistikk.DeleteSykefraværsstatistikkFunction;
@@ -25,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("db-test")
 @ExtendWith(MockitoExtension.class)
 @DataJdbcTest
+@ExtendWith(AmendPrimaryKeyForH2Extension.class)
 public class SykefraværsstatistikkLandUtilsJdbcTest {
 
     private static final String LABEL = "TEST";

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkNæringUtilsJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkNæringUtilsJdbcTest.java
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.provisjonering.importering.integrasjon.utils;
 
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.AmendPrimaryKeyForH2Extension;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.ÅrstallOgKvartal;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.SykefraværsstatistikkNæring;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.statistikk.DeleteSykefraværsstatistikkFunction;
@@ -8,6 +9,7 @@ import no.nav.arbeidsgiver.sykefravarsstatistikk.api.metrikker.besøksstatistikk
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -22,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("db-test")
 @DataJdbcTest
+@ExtendWith(AmendPrimaryKeyForH2Extension.class)
 public class SykefraværsstatistikkNæringUtilsJdbcTest {
 
     @Autowired

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkSektorUtilsJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkSektorUtilsJdbcTest.java
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.provisjonering.importering.integrasjon.utils;
 
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.AmendPrimaryKeyForH2Extension;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.ÅrstallOgKvartal;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.SykefraværsstatistikkSektor;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.statistikk.DeleteSykefraværsstatistikkFunction;
@@ -8,6 +9,7 @@ import no.nav.arbeidsgiver.sykefravarsstatistikk.api.metrikker.besøksstatistikk
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -22,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("db-test")
 @DataJdbcTest
+@ExtendWith(AmendPrimaryKeyForH2Extension.class)
 public class SykefraværsstatistikkSektorUtilsJdbcTest {
 
     @Autowired

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkVirksomhetUtilsJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkVirksomhetUtilsJdbcTest.java
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.provisjonering.importering.integrasjon.utils;
 
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.AmendPrimaryKeyForH2Extension;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.ÅrstallOgKvartal;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.SykefraværsstatistikkVirksomhet;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.statistikk.BatchCreateSykefraværsstatistikkFunction;
@@ -9,6 +10,7 @@ import no.nav.arbeidsgiver.sykefravarsstatistikk.api.metrikker.besøksstatistikk
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -20,13 +22,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.DatavarehusRepository.RECTYPE_FOR_VIRKSOMHET;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.Varighetskategori._1_DAG_TIL_7_DAGER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("db-test")
 @DataJdbcTest
+@ExtendWith(AmendPrimaryKeyForH2Extension.class)
 public class SykefraværsstatistikkVirksomhetUtilsJdbcTest {
 
     @Autowired
@@ -41,7 +43,6 @@ public class SykefraværsstatistikkVirksomhetUtilsJdbcTest {
     public void setUp() {
         utils = new SykefraværsstatistikkVirksomhetUtils(namedParameterJdbcTemplate);
         cleanUpLokalTestDb(namedParameterJdbcTemplate);
-        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "sykefravar_statistikk_virksomhet");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkVirksomhetUtilsJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/importering/provisjonering/importering/integrasjon/utils/SykefraværsstatistikkVirksomhetUtilsJdbcTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.DatavarehusRepository.RECTYPE_FOR_VIRKSOMHET;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.Varighetskategori._1_DAG_TIL_7_DAGER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +41,7 @@ public class SykefraværsstatistikkVirksomhetUtilsJdbcTest {
     public void setUp() {
         utils = new SykefraværsstatistikkVirksomhetUtils(namedParameterJdbcTemplate);
         cleanUpLokalTestDb(namedParameterJdbcTemplate);
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "sykefravar_statistikk_virksomhet");
     }
 
     @AfterEach
@@ -163,5 +165,4 @@ public class SykefraværsstatistikkVirksomhetUtilsJdbcTest {
                 new MapSqlParameterSource()
         );
     }
-
 }

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/metrikker/besøksstatistikk/BesøksstatistikkRepositoryJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/metrikker/besøksstatistikk/BesøksstatistikkRepositoryJdbcTest.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 
 import static java.lang.String.format;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestData.*;
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @ActiveProfiles("db-test")
@@ -31,6 +32,10 @@ public class BesøksstatistikkRepositoryJdbcTest {
     public void setUp() {
         repository = new BesøksstatistikkRepository(namedParameterJdbcTemplate);
         cleanUpTestDb(namedParameterJdbcTemplate);
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "besoksstatistikk_altinn_roller");
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "besoksstatistikk_smaa_virksomheter");
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "besoksstatistikk_unikt_besok");
+        setAutoincrementPrimaryKeyForH2Db(namedParameterJdbcTemplate, "besoksstatistikk_virksomhet");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/SykefraværForEttKvartalRepositoryJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/SykefraværForEttKvartalRepositoryJdbcTest.java
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.sykefraværshistorikk;
 
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.AmendPrimaryKeyForH2Extension;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Næring;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Næringskode5Siffer;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Orgnr;
@@ -13,6 +14,7 @@ import no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.sykefraværshist
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -23,13 +25,13 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
-import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllStatistikkFraDatabase;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.Varighetskategori._1_DAG_TIL_7_DAGER;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @ActiveProfiles("db-test")
 @DataJdbcTest
+@ExtendWith(AmendPrimaryKeyForH2Extension.class)
 public class SykefraværForEttKvartalRepositoryJdbcTest {
     @Autowired
     private NamedParameterJdbcTemplate jdbcTemplate;
@@ -40,11 +42,6 @@ public class SykefraværForEttKvartalRepositoryJdbcTest {
     public void setUp() {
         kvartalsvisSykefraværprosentRepository = new KvartalsvisSykefraværRepository(jdbcTemplate);
         slettAllStatistikkFraDatabase(jdbcTemplate);
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_land");
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_virksomhet");
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_naring5siffer");
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_sektor");
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_naring");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/SykefraværForEttKvartalRepositoryJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/SykefraværForEttKvartalRepositoryJdbcTest.java
@@ -1,8 +1,13 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.sykefraværshistorikk;
 
-import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.*;
-import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.bransjeprogram.Bransje;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Næring;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Næringskode5Siffer;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Orgnr;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Sektor;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Underenhet;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.bransjeprogram.ArbeidsmiljøportalenBransje;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.bransjeprogram.Bransje;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.ÅrstallOgKvartal;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.Varighetskategori;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.sykefraværshistorikk.kvartalsvis.KvartalsvisSykefraværRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -18,6 +23,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllStatistikkFraDatabase;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.Varighetskategori._1_DAG_TIL_7_DAGER;
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -34,6 +40,11 @@ public class SykefraværForEttKvartalRepositoryJdbcTest {
     public void setUp() {
         kvartalsvisSykefraværprosentRepository = new KvartalsvisSykefraværRepository(jdbcTemplate);
         slettAllStatistikkFraDatabase(jdbcTemplate);
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_land");
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_virksomhet");
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_naring5siffer");
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_sektor");
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_naring");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/SykefraværRepositoryJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/SykefraværRepositoryJdbcTest.java
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.sykefraværshistorikk;
 
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.AmendPrimaryKeyForH2Extension;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Næringskode5Siffer;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Orgnr;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Underenhet;
@@ -9,6 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -23,6 +25,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @ActiveProfiles("db-test")
 @DataJdbcTest
+@ExtendWith(AmendPrimaryKeyForH2Extension.class)
 public class SykefraværRepositoryJdbcTest {
     @Autowired
     private NamedParameterJdbcTemplate jdbcTemplate;

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/summert/GraderingRepositoryJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/summert/GraderingRepositoryJdbcTest.java
@@ -1,18 +1,20 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.sykefraværshistorikk.summert;
 
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.AmendPrimaryKeyForH2Extension;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.InstitusjonellSektorkode;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Næring;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Næringskode5Siffer;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Orgnr;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.OverordnetEnhet;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Underenhet;
-import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.bransjeprogram.Bransje;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.bransjeprogram.ArbeidsmiljøportalenBransje;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.bransjeprogram.Bransje;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.ÅrstallOgKvartal;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.sykefraværshistorikk.UmaskertSykefraværForEttKvartal;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -22,7 +24,6 @@ import org.springframework.test.context.ActiveProfiles;
 import java.math.BigDecimal;
 import java.util.List;
 
-import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllStatistikkFraDatabase;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.DatavarehusRepository.RECTYPE_FOR_FORETAK;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.DatavarehusRepository.RECTYPE_FOR_VIRKSOMHET;
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("db-test")
 @DataJdbcTest
+@ExtendWith(AmendPrimaryKeyForH2Extension.class)
 public class GraderingRepositoryJdbcTest {
 
     private static final Næring PRODUKSJON_AV_KLÆR = new Næring("14", "Produksjon av klær");
@@ -66,7 +68,6 @@ public class GraderingRepositoryJdbcTest {
     public void setUp() {
         graderingRepository = new GraderingRepository(jdbcTemplate);
         slettAllStatistikkFraDatabase(jdbcTemplate);
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_virksomhet_med_gradering");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/summert/GraderingRepositoryJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/summert/GraderingRepositoryJdbcTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.math.BigDecimal;
 import java.util.List;
 
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllStatistikkFraDatabase;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.DatavarehusRepository.RECTYPE_FOR_FORETAK;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.importering.autoimport.DatavarehusRepository.RECTYPE_FOR_VIRKSOMHET;
@@ -65,6 +66,7 @@ public class GraderingRepositoryJdbcTest {
     public void setUp() {
         graderingRepository = new GraderingRepository(jdbcTemplate);
         slettAllStatistikkFraDatabase(jdbcTemplate);
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_virksomhet_med_gradering");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/summert/VarighetRepositoryJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/summert/VarighetRepositoryJdbcTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.math.BigDecimal;
 import java.util.List;
 
+import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllStatistikkFraDatabase;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
@@ -36,6 +37,8 @@ public class VarighetRepositoryJdbcTest {
     public void setUp() {
         varighetRepository = new VarighetRepository(jdbcTemplate);
         slettAllStatistikkFraDatabase(jdbcTemplate);
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_virksomhet");
+        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_naring_med_varighet");
     }
 
     @AfterEach

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/summert/VarighetRepositoryJdbcTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/summert/VarighetRepositoryJdbcTest.java
@@ -1,17 +1,19 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.sykefraværshistorikk.summert;
 
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.AmendPrimaryKeyForH2Extension;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Næring;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Næringskode5Siffer;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Orgnr;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Underenhet;
-import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.bransjeprogram.Bransje;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.bransjeprogram.ArbeidsmiljøportalenBransje;
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.bransjeprogram.Bransje;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.ÅrstallOgKvartal;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.Varighetskategori;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.statistikk.sykefraværshistorikk.UmaskertSykefraværForEttKvartalMedVarighet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -21,12 +23,12 @@ import org.springframework.test.context.ActiveProfiles;
 import java.math.BigDecimal;
 import java.util.List;
 
-import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.setAutoincrementPrimaryKeyForH2Db;
 import static no.nav.arbeidsgiver.sykefravarsstatistikk.api.TestUtils.slettAllStatistikkFraDatabase;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @ActiveProfiles("db-test")
 @DataJdbcTest
+@ExtendWith(AmendPrimaryKeyForH2Extension.class)
 public class VarighetRepositoryJdbcTest {
     @Autowired
     private NamedParameterJdbcTemplate jdbcTemplate;
@@ -37,8 +39,6 @@ public class VarighetRepositoryJdbcTest {
     public void setUp() {
         varighetRepository = new VarighetRepository(jdbcTemplate);
         slettAllStatistikkFraDatabase(jdbcTemplate);
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_virksomhet");
-        setAutoincrementPrimaryKeyForH2Db(jdbcTemplate, "sykefravar_statistikk_naring_med_varighet");
     }
 
     @AfterEach


### PR DESCRIPTION
Følgende lib er oppdatert (tilsvarer 11 PR fra Snyk)
 - Log4j til 2.16.0
 - Shedlock til 4.30.0
 - H2 DB til 2.0.202
 - token-validation-spring til 19.3.0.0
 - springdoc-openapi-ui til 1.6.1
 - unleash til 4.4.1
 - micrometer til 1.8.0