### PR TITLE
Fix code scanning alerts 15 feb 2022

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/oppgraderinger-25-jan-2022'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/fix-code-scanning-alerts-15-feb-2022'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
         <prometheus.version>0.14.1</prometheus.version>
         <mockito-junit-jupiter.version>3.11.2</mockito-junit-jupiter.version>
         <wiremock.version>2.27.2</wiremock.version>
-        <shedlock.shedlock-provider-jdbc-template.version>4.31.0</shedlock.shedlock-provider-jdbc-template.version>
-        <shedlock.version>4.31.0</shedlock.version>
+        <shedlock.shedlock-provider-jdbc-template.version>4.32.0</shedlock.shedlock-provider-jdbc-template.version>
+        <shedlock.version>4.32.0</shedlock.version>
         <unleash.version>4.4.1</unleash.version>
         <no.nav.common-log.version>2.2021.12.09_11.47-999457edc68f</no.nav.common-log.version>
         <net.minidev.json-smart.version>2.4.7</net.minidev.json-smart.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <shedlock.shedlock-provider-jdbc-template.version>4.32.0</shedlock.shedlock-provider-jdbc-template.version>
         <shedlock.version>4.32.0</shedlock.version>
         <unleash.version>4.4.1</unleash.version>
-        <no.nav.common-log.version>2.2021.12.09_11.47-999457edc68f</no.nav.common-log.version>
+        <no.nav.common-log.version>2.2022.01.14_09.11-1d258a7225ea</no.nav.common-log.version>
         <net.minidev.json-smart.version>2.4.7</net.minidev.json-smart.version>
         <com.nimbusds.nimbus-jose-jwt.version>9.15.2</com.nimbusds.nimbus-jose-jwt.version>
         <com.papertrailapp.logback-syslog4j.version>1.0.0</com.papertrailapp.logback-syslog4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <com.nimbusds.nimbus-jose-jwt.version>9.15.2</com.nimbusds.nimbus-jose-jwt.version>
         <com.papertrailapp.logback-syslog4j.version>1.0.0</com.papertrailapp.logback-syslog4j.version>
         <com.squareup.okhttp3.version>4.9.3</com.squareup.okhttp3.version>
-        <org.springdoc.springdoc-openapi-ui.version>1.6.3</org.springdoc.springdoc-openapi-ui.version>
+        <org.springdoc.springdoc-openapi-ui.version>1.6.4</org.springdoc.springdoc-openapi-ui.version>
         <no.nav.vault-jdbc.version>1.3.9</no.nav.vault-jdbc.version>
         <com.oracle.ojdbc.ojdbc8.version>19.3.0.0</com.oracle.ojdbc.ojdbc8.version>
         <com.h2database.h2.version>2.1.210</com.h2database.h2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <com.oracle.ojdbc.ojdbc8.version>19.3.0.0</com.oracle.ojdbc.ojdbc8.version>
         <com.h2database.h2.version>2.1.210</com.h2database.h2.version>
         <org.apache.logging.log4j.version>2.17.1</org.apache.logging.log4j.version>
-        <org.flywaydb.version>8.2.3</org.flywaydb.version>
+        <org.flywaydb.version>8.3.0</org.flywaydb.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <oidc-support.version>1.3.10</oidc-support.version>
         <altinn-rettigheter-proxy-klient.version>2.0.7-rc</altinn-rettigheter-proxy-klient.version>
         <micrometer.version>1.8.1</micrometer.version>
-        <prometheus.version>0.14.1</prometheus.version>
+        <prometheus.version>0.15.0</prometheus.version>
         <mockito-junit-jupiter.version>3.11.2</mockito-junit-jupiter.version>
         <wiremock.version>2.27.2</wiremock.version>
         <shedlock.shedlock-provider-jdbc-template.version>4.32.0</shedlock.shedlock-provider-jdbc-template.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <oauth2-oidc-sdk.version>9.9.1</oauth2-oidc-sdk.version> <!-- TODO: Fjern etter Spring upgrade >= 2.5.x -->
         <oidc-support.version>1.3.10</oidc-support.version>
         <altinn-rettigheter-proxy-klient.version>2.0.7-rc</altinn-rettigheter-proxy-klient.version>
-        <micrometer.version>1.8.1</micrometer.version>
+        <micrometer.version>1.8.2</micrometer.version>
         <prometheus.version>0.15.0</prometheus.version>
         <mockito-junit-jupiter.version>3.11.2</mockito-junit-jupiter.version>
         <wiremock.version>2.27.2</wiremock.version>

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/featuretoggling/FeatureToggleController.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/featuretoggling/FeatureToggleController.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 @RestController
 public class FeatureToggleController {
     private final UnleashService unleashService;
-    private final String UNLEASH_SESSION_COOKIE_NAME = "unleash-session";
+    protected final String UNLEASH_SESSION_COOKIE_NAME = "unleash-session";
 
 
     @Autowired
@@ -39,7 +39,9 @@ public class FeatureToggleController {
 
         if (sessionId == null) {
             sessionId = UUID.randomUUID().toString();
-            response.addCookie(new Cookie(UNLEASH_SESSION_COOKIE_NAME, sessionId));
+            Cookie cookie = new Cookie(UNLEASH_SESSION_COOKIE_NAME, sessionId);
+            cookie.setSecure(true);
+            response.addCookie(cookie);
         }
 
         Map<String, Boolean> toggles = unleashService.hentFeatureToggles(features, sessionId);


### PR DESCRIPTION
 - Fiks code scanning alerts som gjelder `secure` flag på `unleash` cookie (ref: [CS 1](https://github.com/navikt/sykefravarsstatistikk-api/security/code-scanning/1) og [CS 2](https://github.com/navikt/sykefravarsstatistikk-api/security/code-scanning/2)
 - Oppgrader noen avhengigheter (Snyk). 