### PR TITLE
Test data enhetsregisteret + oppdater verif av tokens claims på 'pid' i stedet av 'sub'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/oppgradering-av-spring-boot-etter-springshell-CVE-2022-22965'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/test-data-enhetsregisteret'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/MockServer.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/MockServer.java
@@ -104,8 +104,10 @@ public class MockServer {
         mockKall(WireMock.urlPathMatching(path + "underenheter/910562452"), lesFilSomString("dev_enhetsregisteretUnderenhet_910562452.json"));
         mockKall(WireMock.urlPathMatching(path + "underenheter/910825518"), lesFilSomString("dev_enhetsregisteretUnderenhet_910825518.json"));
         mockKall(WireMock.urlPathMatching(path + "underenheter/910562436"), lesFilSomString("dev_enhetsregisteretUnderenhet_910562436.json"));
+        mockKall(WireMock.urlPathMatching(path + "underenheter/311874411"), lesFilSomString("dev_enhetsregisteretUnderenhet_311874411.json"));
         mockKall(WireMock.urlPathMatching(path + "enheter/[0-9]{9}"), lesFilSomString("enhetsregisteretEnhet.json"));
         mockKall(WireMock.urlPathMatching(path + "enheter/910562223"), lesFilSomString("dev_enhetsregisteretEnhet.json"));
+        mockKall(WireMock.urlPathMatching(path + "enheter/310529915"), lesFilSomString("dev_enhetsregisteretEnhet_310529915.json"));
     }
 
     private void mockKallFraFil(String url, String filnavn) {

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/MockServer.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/MockServer.java
@@ -105,9 +105,11 @@ public class MockServer {
         mockKall(WireMock.urlPathMatching(path + "underenheter/910825518"), lesFilSomString("dev_enhetsregisteretUnderenhet_910825518.json"));
         mockKall(WireMock.urlPathMatching(path + "underenheter/910562436"), lesFilSomString("dev_enhetsregisteretUnderenhet_910562436.json"));
         mockKall(WireMock.urlPathMatching(path + "underenheter/311874411"), lesFilSomString("dev_enhetsregisteretUnderenhet_311874411.json"));
+        mockKall(WireMock.urlPathMatching(path + "underenheter/315829062"), lesFilSomString("dev_enhetsregisteretUnderenhet_315829062.json"));
         mockKall(WireMock.urlPathMatching(path + "enheter/[0-9]{9}"), lesFilSomString("enhetsregisteretEnhet.json"));
         mockKall(WireMock.urlPathMatching(path + "enheter/910562223"), lesFilSomString("dev_enhetsregisteretEnhet.json"));
         mockKall(WireMock.urlPathMatching(path + "enheter/310529915"), lesFilSomString("dev_enhetsregisteretEnhet_310529915.json"));
+        mockKall(WireMock.urlPathMatching(path + "enheter/313068420"), lesFilSomString("dev_enhetsregisteretEnhet_313068420.json"));
     }
 
     private void mockKallFraFil(String url, String filnavn) {

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/tilgangskontroll/TilgangskontrollUtils.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/tilgangskontroll/TilgangskontrollUtils.java
@@ -45,7 +45,6 @@ public class TilgangskontrollUtils {
 
     public InnloggetBruker hentInnloggetBruker() {
         TokenValidationContext context = contextHolder.getTokenValidationContext();
-        log.info(format("[DEBUG][Test miljø] tokenValidationContext er: '%s'", context.toString()));
 
         Optional<JwtTokenClaims> claimsForIssuerSelvbetjening = getClaimsFor(context, ISSUER_SELVBETJENING);
 

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/tilgangskontroll/TilgangskontrollUtils.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/tilgangskontroll/TilgangskontrollUtils.java
@@ -45,6 +45,7 @@ public class TilgangskontrollUtils {
 
     public InnloggetBruker hentInnloggetBruker() {
         TokenValidationContext context = contextHolder.getTokenValidationContext();
+        log.info(format("[DEBUG][Test miljø] tokenValidationContext er: '%s'", context.toString()));
 
         Optional<JwtTokenClaims> claimsForIssuerSelvbetjening = getClaimsFor(context, ISSUER_SELVBETJENING);
         if (claimsForIssuerSelvbetjening.isPresent()) {

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/tilgangskontroll/TilgangskontrollUtils.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/tilgangskontroll/TilgangskontrollUtils.java
@@ -48,7 +48,7 @@ public class TilgangskontrollUtils {
 
         Optional<JwtTokenClaims> claimsForIssuerSelvbetjening = getClaimsFor(context, ISSUER_SELVBETJENING);
         if (claimsForIssuerSelvbetjening.isPresent()) {
-            log.info("[DEBUG][Test miljø] subject er: ", claimsForIssuerSelvbetjening.get().getSubject());
+            log.info(format("[DEBUG][Test miljø] subject er: '%s'", claimsForIssuerSelvbetjening.get().getSubject()));
             return new InnloggetBruker(
                     new Fnr(claimsForIssuerSelvbetjening.get().getSubject()));
         }

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/tilgangskontroll/TilgangskontrollUtils.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/tilgangskontroll/TilgangskontrollUtils.java
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.tilgangskontroll;
 
 import com.google.common.collect.ImmutableSet;
+import lombok.extern.slf4j.Slf4j;
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.Fnr;
 import no.nav.security.token.support.core.context.TokenValidationContext;
 import no.nav.security.token.support.core.context.TokenValidationContextHolder;
@@ -16,6 +17,7 @@ import java.util.Set;
 
 import static java.lang.String.format;
 
+@Slf4j
 @Component
 public class TilgangskontrollUtils {
 
@@ -46,6 +48,7 @@ public class TilgangskontrollUtils {
 
         Optional<JwtTokenClaims> claimsForIssuerSelvbetjening = getClaimsFor(context, ISSUER_SELVBETJENING);
         if (claimsForIssuerSelvbetjening.isPresent()) {
+            log.info("[DEBUG][Test miljø] subject er: ", claimsForIssuerSelvbetjening.get().getSubject());
             return new InnloggetBruker(
                     new Fnr(claimsForIssuerSelvbetjening.get().getSubject()));
         }

--- a/src/main/resources/mock/dev_enhetsregisteretEnhet_310529915.json
+++ b/src/main/resources/mock/dev_enhetsregisteretEnhet_310529915.json
@@ -1,0 +1,64 @@
+{
+  "organisasjonsnummer": "SPISS SJOKKERT TIGER AS",
+  "navn": "",
+  "organisasjonsform": {
+    "kode": "AS",
+    "beskrivelse": "Aksjeselskap",
+    "_links": {
+      "self": {
+        "href": "https://data.brreg.no/enhetsregisteret/api/organisasjonsformer/AS"
+      }
+    }
+  },
+  "hjemmeside": "www.nav.no",
+  "postadresse": {
+    "land": "Norge",
+    "landkode": "NO",
+    "postnummer": "0130",
+    "poststed": "OSLO",
+    "adresse": [
+      "Postboks 6944 St Olavs Plass"
+    ],
+    "kommune": "OSLO",
+    "kommunenummer": "0301"
+  },
+  "registreringsdatoEnhetsregisteret": "2012-12-12",
+  "registrertIMvaregisteret": false,
+  "naeringskode1": {
+    "beskrivelse": "Trygdeordninger underlagt offentlig forvaltning",
+    "kode": "84.300"
+  },
+  "antallAnsatte": 1621,
+  "overordnetEnhet": "991012206",
+  "forretningsadresse": {
+    "land": "Norge",
+    "landkode": "NO",
+    "postnummer": "0164",
+    "poststed": "OSLO",
+    "adresse": [
+      "C. J. Hambros Plass 2A"
+    ],
+    "kommune": "OSLO",
+    "kommunenummer": "0301"
+  },
+  "stiftelsesdato": "2012-06-18",
+  "institusjonellSektorkode": {
+    "kode": "8300",
+    "beskrivelse": "Statsforvaltningen"
+  },
+  "registrertIForetaksregisteret": false,
+  "registrertIStiftelsesregisteret": false,
+  "registrertIFrivillighetsregisteret": false,
+  "konkurs": false,
+  "underAvvikling": false,
+  "underTvangsavviklingEllerTvangsopplosning": false,
+  "maalform": "Bokmål",
+  "_links": {
+    "self": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/999263550"
+    },
+    "overordnetEnhet": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/991012206"
+    }
+  }
+}

--- a/src/main/resources/mock/dev_enhetsregisteretEnhet_310529915.json
+++ b/src/main/resources/mock/dev_enhetsregisteretEnhet_310529915.json
@@ -1,6 +1,6 @@
 {
-  "organisasjonsnummer": "SPISS SJOKKERT TIGER AS",
-  "navn": "",
+  "organisasjonsnummer": "310529915",
+  "navn": "SPISS SJOKKERT TIGER AS",
   "organisasjonsform": {
     "kode": "AS",
     "beskrivelse": "Aksjeselskap",

--- a/src/main/resources/mock/dev_enhetsregisteretEnhet_313068420.json
+++ b/src/main/resources/mock/dev_enhetsregisteretEnhet_313068420.json
@@ -1,6 +1,6 @@
 {
-  "organisasjonsnummer": "310529915",
-  "navn": "SPISS SJOKKERT TIGER AS",
+  "organisasjonsnummer": "313068420",
+  "navn": "TILLITSFULL PEN TIGER AS",
   "organisasjonsform": {
     "kode": "AS",
     "beskrivelse": "Aksjeselskap",
@@ -25,10 +25,10 @@
   "registreringsdatoEnhetsregisteret": "2012-12-12",
   "registrertIMvaregisteret": false,
   "naeringskode1": {
-    "beskrivelse": "Sykehjem",
-    "kode": "87.101"
+    "beskrivelse": "Oppføring av bygninger",
+    "kode": "41.200"
   },
-  "antallAnsatte": 1621,
+  "antallAnsatte": 76,
   "forretningsadresse": {
     "land": "Norge",
     "landkode": "NO",
@@ -54,10 +54,7 @@
   "maalform": "Bokmål",
   "_links": {
     "self": {
-      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/999263550"
-    },
-    "overordnetEnhet": {
-      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/991012206"
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/313068420"
     }
   }
 }

--- a/src/main/resources/mock/dev_enhetsregisteretUnderenhet_311874411.json
+++ b/src/main/resources/mock/dev_enhetsregisteretUnderenhet_311874411.json
@@ -1,0 +1,53 @@
+{
+  "organisasjonsnummer": "311874411",
+  "navn": "SPISS SJOKKERT TIGER AS",
+  "organisasjonsform": {
+    "kode": "BEDR",
+    "beskrivelse": "Bedrift",
+    "_links": {
+      "self": {
+        "href": "https://data.brreg.no/enhetsregisteret/api/organisasjonsformer/BEDR"
+      }
+    }
+  },
+  "postadresse": {
+    "land": "Norge",
+    "landkode": "NO",
+    "postnummer": "0614",
+    "poststed": "OSLO",
+    "adresse": [
+      "Postboks 325  Alnabru"
+    ],
+    "kommune": "OSLO",
+    "kommunenummer": "0301"
+  },
+  "registreringsdatoEnhetsregisteret": "2009-11-30",
+  "registrertIMvaregisteret": false,
+  "naeringskode1": {
+    "beskrivelse": "Sykehjem",
+    "kode": "87.101"
+  },
+  "antallAnsatte": 78,
+  "overordnetEnhet": "310529915",
+  "oppstartsdato": "2012-01-01",
+  "datoEierskifte": "2013-01-01",
+  "beliggenhetsadresse": {
+    "land": "Norge",
+    "landkode": "NO",
+    "postnummer": "0663",
+    "poststed": "OSLO",
+    "adresse": [
+      "Fredrik Selmers vei 2"
+    ],
+    "kommune": "OSLO",
+    "kommunenummer": "0301"
+  },
+  "_links": {
+    "self": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/underenheter/311874411"
+    },
+    "overordnetEnhet": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/310529915"
+    }
+  }
+}

--- a/src/main/resources/mock/dev_enhetsregisteretUnderenhet_315829062.json
+++ b/src/main/resources/mock/dev_enhetsregisteretUnderenhet_315829062.json
@@ -1,0 +1,53 @@
+{
+  "organisasjonsnummer": "315829062",
+  "navn": "TILLITSFULL PEN TIGER AS",
+  "organisasjonsform": {
+    "kode": "BEDR",
+    "beskrivelse": "Bedrift",
+    "_links": {
+      "self": {
+        "href": "https://data.brreg.no/enhetsregisteret/api/organisasjonsformer/BEDR"
+      }
+    }
+  },
+  "postadresse": {
+    "land": "Norge",
+    "landkode": "NO",
+    "postnummer": "0614",
+    "poststed": "OSLO",
+    "adresse": [
+      "Postboks 325  Alnabru"
+    ],
+    "kommune": "OSLO",
+    "kommunenummer": "0301"
+  },
+  "registreringsdatoEnhetsregisteret": "2009-11-30",
+  "registrertIMvaregisteret": false,
+  "naeringskode1": {
+    "beskrivelse": "Oppføring av bygninger",
+    "kode": "41.200"
+  },
+  "antallAnsatte": 78,
+  "overordnetEnhet": "313068420",
+  "oppstartsdato": "2012-01-01",
+  "datoEierskifte": "2013-01-01",
+  "beliggenhetsadresse": {
+    "land": "Norge",
+    "landkode": "NO",
+    "postnummer": "0663",
+    "poststed": "OSLO",
+    "adresse": [
+      "Fredrik Selmers vei 2"
+    ],
+    "kommune": "OSLO",
+    "kommunenummer": "0301"
+  },
+  "_links": {
+    "self": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/underenheter/315829062"
+    },
+    "overordnetEnhet": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/313068420"
+    }
+  }
+}

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/ApiErrorMappingTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/ApiErrorMappingTest.java
@@ -46,7 +46,6 @@ public class ApiErrorMappingTest extends SpringIntegrationTestbase {
                                         mockOAuth2Server,
                                         "15008462396",
                                         SELVBETJENING_ISSUER_ID,
-                                        "",
                                         ""
                                 )
                         )

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/TestTokenUtil.java
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/TestTokenUtil.java
@@ -12,28 +12,31 @@ public class TestTokenUtil {
     public static String SELVBETJENING_ISSUER_ID = "selvbetjening";
     public static String TOKENX_ISSUER_ID = "tokenx";
 
+
     public static String createToken(
             MockOAuth2Server oAuth2Server,
-            String sub,
-            String issuerId
+            String pid,
+            String issuerId,
+            String idp
     ) {
-        return createToken(oAuth2Server, sub, issuerId, null, null);
+
+        return createToken(oAuth2Server, pid, "IKKE_I_BRUK_LENGER", issuerId, idp);
     }
 
     public static String createToken(
             MockOAuth2Server oAuth2Server,
+            String pid,
             String sub,
             String issuerId,
-            String idp,
-            String pid
+            String idp
     ) {
         Map<String, String> claims = new HashMap<>();
 
-        if(StringUtils.isNoneEmpty(idp)) {
+        if (StringUtils.isNoneEmpty(idp)) {
             claims.put("idp", idp);
         }
 
-        if(StringUtils.isNoneEmpty(pid)) {
+        if (StringUtils.isNoneEmpty(pid)) {
             claims.put("pid", pid);
         }
         String tokenIssuedByOAuth2Server = oAuth2Server.issueToken(


### PR DESCRIPTION
Denne PR inneholder to uavhengige endringer: 
 - Verifisering av innloggingstoken sjekker FNR hentet fra den `pid` claim (men med fortsatt uthenting fra `sub` claims i den perioden spesifikasjonene til logginservice er oppdatert i test men ikke i prod enda)
 - lagt til to nye underenhet og to tilsvarende overordnet enhet i den enhetsregisteret mock (enhetsregisteret har ikke noe test miljø i motsetning av Altinn og folkeregisteret/skattetaten hvor de nye test brukere og fiktive bedrifter kan finnes -- se egen dok i Teams mappen)   