### PR TITLE
åpne endepunkt for legemeldt sykefravær

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/summert/SummertLegemeldtSykefraværService.java
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/statistikk/sykefraværshistorikk/summert/SummertLegemeldtSykefraværService.java
@@ -45,7 +45,16 @@ public class SummertLegemeldtSykefraværService {
     if (harData && !erMaskert) {
       return new LegemeldtSykefraværsprosent(
           Statistikkategori.VIRKSOMHET, underenhet.getNavn(), summertSykefravær.getProsent());
+    } else {
+      return hentLegemeldtSykefraværsprosentUtenStatistikkForVirksomhet(underenhet,
+          sistePubliserteÅrstallOgKvartal);
     }
+  }
+
+  public LegemeldtSykefraværsprosent hentLegemeldtSykefraværsprosentUtenStatistikkForVirksomhet(
+      Underenhet underenhet, ÅrstallOgKvartal sistePubliserteÅrstallOgKvartal) {
+    ÅrstallOgKvartal eldsteÅrstallOgKvartal = sistePubliserteÅrstallOgKvartal.minusKvartaler(3);
+
     BransjeEllerNæring bransjeEllerNæring =
         bransjeEllerNæringService.bestemFraNæringskode(underenhet.getNæringskode());
 


### PR DESCRIPTION
tillat brukere med minst én rettighet på virksomhet å hente ut legemeldt sykefraværsprosent for bransje og næring fra endepunkt. dette vil gjøre at sykefraværsprosent kan vises på flisa til forebygge fravær på min side arbeidsgiver også for disse brukerne