### PR TITLE
Teamia tar over forebyggingsplan fra pia

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
   build-and-push-image:
     name: Build and push Docker image
     needs: test
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/fiks-sektor-topic'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/teamia-tar-over-forebyggingsplan-fra-pia'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
   deploy-to-dev:
     name: Deploy to dev
     needs: build-and-push-image
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/fiks-sektor-topic'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/teamia-tar-over-forebyggingsplan-fra-pia'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -27,7 +27,7 @@ spec:
           namespace: teamia
           cluster: dev-gcp
         - application: forebyggingsplan-frontend
-          namespace: pia
+          namespace: teamia
           cluster: dev-gcp
     outbound:
       rules:

--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -27,7 +27,7 @@ spec:
           namespace: teamia
           cluster: dev-gcp
         - application: forebyggingsplan-frontend
-          namespace: teamia
+          namespace: pia
           cluster: dev-gcp
     outbound:
       rules:

--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -22,12 +22,12 @@ spec:
           cluster: dev-gcp
         - application: min-side-arbeidsgiver
           namespace: fager
-          cluster: dev-gcp  
+          cluster: dev-gcp
         - application: min-ia
           namespace: teamia
           cluster: dev-gcp
         - application: forebyggingsplan-frontend
-          namespace: pia
+          namespace: teamia
           cluster: dev-gcp
     outbound:
       rules:

--- a/nais/prod.yaml
+++ b/nais/prod.yaml
@@ -27,7 +27,7 @@ spec:
           namespace: teamia
           cluster: prod-gcp
         - application: forebyggingsplan-frontend
-          namespace: pia
+          namespace: teamia
           cluster: prod-gcp
     outbound:
       rules:


### PR DESCRIPTION
Forebyggingsplan front-end er flyttet til namespace `teamia`
Denne endringen innebærer endringer i konfig slik at kall fra teamia.foreebyggingsplan-frontend er tillatt