### PR TITLE
Add hasher

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/felles/hash/Hasher.kt
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/felles/hash/Hasher.kt
@@ -1,0 +1,6 @@
+package no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.hash
+
+interface Hasher {
+    fun hash(data: String, salt: ByteArray): ByteArray
+    fun generateRandomSalt(): ByteArray
+}

--- a/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/felles/hash/Sha3Hasher.kt
+++ b/src/main/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/felles/hash/Sha3Hasher.kt
@@ -1,0 +1,27 @@
+package no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.hash
+
+import org.springframework.stereotype.Component
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+@Component
+class Sha3Hasher : Hasher {
+    private val messageDigest get() = MessageDigest.getInstance("SHA3-256")
+    private val charset = Charsets.UTF_8
+
+    override fun hash(data: String, salt: ByteArray): ByteArray {
+        val hashedData = messageDigest.apply {
+            update(data.toByteArray(charset))
+            update(salt)
+        }.digest()
+
+        return hashedData
+    }
+
+    override fun generateRandomSalt(): ByteArray {
+        val salt = ByteArray(32)
+        SecureRandom().nextBytes(salt)
+        return salt
+    }
+}
+

--- a/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/felles/Sha3HasherTest.kt
+++ b/src/test/java/no/nav/arbeidsgiver/sykefravarsstatistikk/api/felles/Sha3HasherTest.kt
@@ -1,0 +1,38 @@
+package no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles
+
+import no.nav.arbeidsgiver.sykefravarsstatistikk.api.felles.hash.Sha3Hasher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class Sha3HasherTest {
+    private val hasher = Sha3Hasher()
+
+    @Test
+    fun `hasher should always hash to the same value given the same salt`() {
+        val data = "Data to be hashed"
+        val salt = "Salt".toByteArray()
+        val result = hasher.hash(data, salt)
+
+        assertThat(result).isEqualTo(
+            "4ce65935eb85af6941f49702d764b516ce12284b113f48871cfb76b763e1634a".hexStringToByteArray()
+        )
+    }
+
+    @Test
+    fun `hasher should always hash to a different value given different salts`() {
+        val data = "Data to be hashed"
+        val firstSalt = hasher.generateRandomSalt()
+        val secondSalt = hasher.generateRandomSalt()
+        val firstResult = hasher.hash(data, firstSalt)
+        val secondResult = hasher.hash(data, secondSalt)
+
+        assertThat(firstResult).isNotEqualTo(secondResult)
+    }
+
+    private fun String.hexStringToByteArray(): ByteArray {
+        return chunked(2)
+            .map { it.toIntOrNull(16) ?: 0 }
+            .map { it.toByte() }
+            .toByteArray()
+    }
+}


### PR DESCRIPTION
Gikk for Javas innebygde funksjonalitet for hashing og valgte SHA3 basert på følgende.

> When deciding whether to use SHA3-256 or SHA2-256 for a new application, there are several factors to consider, such as security, speed, and compatibility.
> 
> Security: SHA3-256 is part of the SHA-3 family, which was developed through a public competition and uses a different cryptographic approach called sponge construction [[2]](https://codesigningstore.com/hash-algorithm-comparison). SHA-3 is not considered a full replacement for SHA-2 but rather an improvement to the overall hash algorithm toolkit [[2]](https://codesigningstore.com/hash-algorithm-comparison). On the other hand, SHA2-256 is part of the SHA-2 family, which has a similar underlying math to SHA-1, making it potentially more vulnerable to certain attacks [[8]](https://www.csoonline.com/article/3256088/why-arent-we-using-sha3.html).
> 
> Speed: In software implementations, SHA-3 has been criticized for being slower than SHA-2 [[3]](https://en.wikipedia.org/wiki/SHA-3). For instance, SHA-1 is more than three times faster and SHA-512 is more than twice as fast as SHA3-512 on Intel CPUs [[8]](https://www.csoonline.com/article/3256088/why-arent-we-using-sha3.html). However, in hardware implementations, SHA-3 is notably faster than all other finalists, including SHA-2 [[3]](https://en.wikipedia.org/wiki/SHA-3).
> 
> Compatibility: SHA-2 is more widely supported in software and hardware, while SHA-3 is still relatively new and not as widely supported [[8]](https://www.csoonline.com/article/3256088/why-arent-we-using-sha3.html). However, some hardware and software libraries are starting to support SHA-3, and this support is expected to grow in the future [[3]](https://en.wikipedia.org/wiki/SHA-3).
> 
> Considering these factors, if security is a higher priority and compatibility is not a concern, you may opt for SHA3-256. However, if speed and compatibility are more important, SHA2-256 might be the better choice.
> 
> It's important to note that NIST does not see SHA-3 as a full replacement for SHA-2, so using SHA2-256 is still considered a secure option [[2]](https://codesigningstore.com/hash-algorithm-comparison). As technology evolves and SHA-3 becomes more widely supported, you can consider transitioning to SHA3-256 in the future.