### PR TITLE
Fjern vavr som avhengighet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
         <ia-felles.version>1.0.0</ia-felles.version>
         <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>
         <logstash-logback-encoder.version>7.4</logstash-logback-encoder.version>
-        <vavr.version>0.10.4</vavr.version>
         <mockito-kotlin.version>5.1.0</mockito-kotlin.version>
         <kotlinx-coroutines-core-jvm.version>1.6.4</kotlinx-coroutines-core-jvm.version>
         <kotest-assertions-core-jvm.version>5.6.2</kotest-assertions-core-jvm.version>
@@ -199,11 +198,6 @@
             <groupId>net.javacrumbs.shedlock</groupId>
             <artifactId>shedlock-provider-jdbc-template</artifactId>
             <version>${shedlock.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.vavr</groupId>
-            <artifactId>vavr</artifactId>
-            <version>${vavr.version}</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/applikasjon/fellesdomene/BransjeEllerNæring.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/applikasjon/fellesdomene/BransjeEllerNæring.kt
@@ -1,36 +1,27 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.applikasjon.fellesdomene
 
 import ia.felles.definisjoner.bransjer.Bransje
-import io.vavr.control.Either
 
 class BransjeEllerNæring {
-    val verdi: Either<Bransje, Næring>
+    val bransje: Bransje?
+    val næring: Næring?
 
     constructor(bransje: Bransje) {
-        verdi = Either.left(bransje)
+        this.bransje = bransje
+        this.næring = null
     }
 
     constructor(næring: Næring) {
-        verdi = Either.right(næring)
+        this.bransje = null
+        this.næring = næring
     }
 
     val statistikkategori: Statistikkategori
-        get() = if (verdi.isLeft) {
+        get() = if (bransje != null) {
             Statistikkategori.BRANSJE
         } else {
             Statistikkategori.NÆRING
         }
-    val isBransje: Boolean
-        get() = verdi.isLeft
 
-    fun getBransje(): Bransje {
-        return verdi.left
-    }
-
-    fun navn(): String {
-        return if (isBransje) verdi.left.navn else verdi.get().navn
-    }
-
-    val næring: Næring
-        get() = verdi.get()
+    fun navn(): String = bransje?.navn ?: næring!!.navn
 }

--- a/src/test/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/applikasjon/fellesdomene/BransjeEllerNæringTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/applikasjon/fellesdomene/BransjeEllerNæringTest.kt
@@ -1,25 +1,23 @@
 package no.nav.arbeidsgiver.sykefravarsstatistikk.api.applikasjon.fellesdomene
 
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Test
 import ia.felles.definisjoner.bransjer.Bransje
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
 internal class BransjeEllerNæringTest {
     @Test
     fun BransjeEllerNæring_kan_opprettes_for_en_bransje_og_returnerer_en_bransje() {
         val bransje = Bransje.BARNEHAGER
         val bransjeEllerNæring = BransjeEllerNæring(bransje)
-        assertThat(bransjeEllerNæring.isBransje).isEqualTo(true)
-        assertThat(bransjeEllerNæring.getBransje()).isEqualTo(bransje)
-        assertThrows(NoSuchElementException::class.java) { bransjeEllerNæring.næring }
+        assertThat(bransjeEllerNæring.bransje).isEqualTo(bransje)
+        assertThat(bransjeEllerNæring.næring).isEqualTo(null)
     }
 
     @Test
     fun BransjeEllerNæring_kan_opprettes_for_en_næring_og_returnerer_en_næring() {
         val næring = Næring("61")
         val bransjeEllerNæring = BransjeEllerNæring(næring)
-        assertThat(bransjeEllerNæring.isBransje).isEqualTo(false)
         assertThat(bransjeEllerNæring.næring).isEqualTo(næring)
-        assertThrows(NoSuchElementException::class.java) { bransjeEllerNæring.getBransje() }
+        assertThat(bransjeEllerNæring.bransje).isEqualTo(null)
     }
 }


### PR DESCRIPTION
Syns ikke det ga mening å erstatte den med Arrow sin Either da den er ment å inneholde en feil og en suksess. Hadde nok vært fint å skrive seg bort fra `BransjeEllerNæring` klassen, men tok ikke det i denne omgangen.