### PR TITLE
Dependency update apr 2024

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
       - name: Run tests
         run: mvn test

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - compose-oppsett
+      - dependency-update-apr-2024
     paths-ignore:
       - '**.md'
       - '**/**.md'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,7 +74,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 21
         cache: maven
 
     - name: Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/navikt/baseimages/temurin:17
+FROM ghcr.io/navikt/baseimages/temurin:21
 ENV APPD_ENABLED=false
 ENV APP_NAME=sykefravarsstatistikk-api
 COPY import-vault-secrets.sh /init-scripts

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <token-support.version>3.2.0</token-support.version>
 
         <!-- Data manipulation -->
-        <json-smart.version>2.5.0</json-smart.version>
+        <json-smart.version>2.5.1</json-smart.version>
         <jackson-dataformat-csv.version>2.17.0</jackson-dataformat-csv.version>
 
         <!-- Database & Persistence -->
@@ -69,11 +69,11 @@
         <prometheus.version>0.16.0</prometheus.version>
 
         <!-- Syntaxic sugar -->
-        <arrow-core.version>1.1.5</arrow-core.version>
+        <arrow-core.version>1.2.4</arrow-core.version>
 
         <!-- Mocking & Testing -->
         <h2.version>2.2.224</h2.version>
-        <json-unit-assertj.version>2.36.1</json-unit-assertj.version>
+        <json-unit-assertj.version>3.2.7</json-unit-assertj.version>
         <kotest-assertions-core-jvm.version>5.8.1</kotest-assertions-core-jvm.version>
         <mockito-kotlin.version>5.3.1</mockito-kotlin.version>
         <mockk-jvm.version>1.13.10</mockk-jvm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <altinn-rettigheter-proxy-klient.version>3.1.0</altinn-rettigheter-proxy-klient.version>
         <micrometer.version>1.11.2</micrometer.version>
         <prometheus.version>0.16.0</prometheus.version>
-        <wiremock.version>3.3.1</wiremock.version>
+        <wiremock.version>3.5.2</wiremock.version>
         <shedlock.version>5.6.0</shedlock.version>
         <shedlock-provider-jdbc-template.version>4.33.0
         </shedlock-provider-jdbc-template.version>
@@ -51,12 +51,12 @@
         <h2.version>2.2.224</h2.version>
         <jetbrainsExposedVersion>0.42.0</jetbrainsExposedVersion>
         <spring-boot-starter-parent.version>3.1.2</spring-boot-starter-parent.version>
-        <mockk-jvm.version>1.13.8</mockk-jvm.version>
+        <mockk-jvm.version>1.13.10</mockk-jvm.version>
         <flyway-maven-plugin.version>10.1.0</flyway-maven-plugin.version>
         <ia-felles.version>1.0.0</ia-felles.version>
         <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>
         <logstash-logback-encoder.version>7.4</logstash-logback-encoder.version>
-        <mockito-kotlin.version>5.1.0</mockito-kotlin.version>
+        <mockito-kotlin.version>5.3.1</mockito-kotlin.version>
         <kotlinx-coroutines-core-jvm.version>1.6.4</kotlinx-coroutines-core-jvm.version>
         <kotest-assertions-core-jvm.version>5.6.2</kotest-assertions-core-jvm.version>
         <json-unit-assertj.version>2.36.1</json-unit-assertj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,35 +32,52 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <kotlin.version>1.9.0</kotlin.version>
-        <token-support.version>3.2.0</token-support.version>
+        <!-- Authentification / Authorization -->
         <altinn-rettigheter-proxy-klient.version>3.1.0</altinn-rettigheter-proxy-klient.version>
-        <micrometer.version>1.11.2</micrometer.version>
-        <prometheus.version>0.16.0</prometheus.version>
-        <wiremock.version>3.5.2</wiremock.version>
+        <nimbus-jose-jwt.version>9.37.2</nimbus-jose-jwt.version>
+        <token-support.version>3.2.0</token-support.version>
+
+        <!-- Data manipulation -->
+        <json-smart.version>2.5.0</json-smart.version>
+        <jackson-dataformat-csv.version>2.17.0</jackson-dataformat-csv.version>
+
+        <!-- Database & Persistence -->
+        <flyway-maven-plugin.version>10.1.0</flyway-maven-plugin.version>
+        <ojdbc8.version>19.3.0.0</ojdbc8.version>
         <shedlock.version>5.6.0</shedlock.version>
         <shedlock-provider-jdbc-template.version>4.33.0
         </shedlock-provider-jdbc-template.version>
-        <common-log.version>2.2023.01.10_13.49-81ddc732df3a</common-log.version>
-        <json-smart.version>2.5.0</json-smart.version>
-        <nimbus-jose-jwt.version>9.37.2</nimbus-jose-jwt.version>
-        <logback-syslog4j.version>1.0.0</logback-syslog4j.version>
-        <okhttp3.version>5.0.0-alpha.12</okhttp3.version>
         <vault-jdbc.version>1.3.10</vault-jdbc.version>
-        <ojdbc8.version>19.3.0.0</ojdbc8.version>
-        <h2.version>2.2.224</h2.version>
-        <jetbrainsExposedVersion>0.42.0</jetbrainsExposedVersion>
-        <spring-boot-starter-parent.version>3.1.2</spring-boot-starter-parent.version>
-        <mockk-jvm.version>1.13.10</mockk-jvm.version>
-        <flyway-maven-plugin.version>10.1.0</flyway-maven-plugin.version>
-        <ia-felles.version>1.0.0</ia-felles.version>
-        <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>
-        <logstash-logback-encoder.version>7.4</logstash-logback-encoder.version>
-        <mockito-kotlin.version>5.3.1</mockito-kotlin.version>
+
+        <!-- Kotlin -->
+        <kotlin.version>1.9.0</kotlin.version>
         <kotlinx-coroutines-core-jvm.version>1.6.4</kotlinx-coroutines-core-jvm.version>
-        <kotest-assertions-core-jvm.version>5.6.2</kotest-assertions-core-jvm.version>
-        <json-unit-assertj.version>2.36.1</json-unit-assertj.version>
+
+        <!-- Framework -->
+        <ia-felles.version>1.0.0</ia-felles.version>
+        <jetbrainsExposedVersion>0.42.0</jetbrainsExposedVersion>
+        <okhttp3.version>5.0.0-alpha.12</okhttp3.version>
+        <spring-boot-starter-parent.version>3.1.2</spring-boot-starter-parent.version>
+        <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>
+
+        <!-- Logging & Observability -->
+        <common-log.version>2.2023.01.10_13.49-81ddc732df3a</common-log.version>
+        <ch.qos.logback.version>1.5.4</ch.qos.logback.version>
+        <logback-syslog4j.version>1.0.0</logback-syslog4j.version>
+        <logstash-logback-encoder.version>7.4</logstash-logback-encoder.version>
+        <micrometer.version>1.12.5</micrometer.version>
+        <prometheus.version>0.16.0</prometheus.version>
+
+        <!-- Syntaxic sugar -->
         <arrow-core.version>1.1.5</arrow-core.version>
+
+        <!-- Mocking & Testing -->
+        <h2.version>2.2.224</h2.version>
+        <json-unit-assertj.version>2.36.1</json-unit-assertj.version>
+        <kotest-assertions-core-jvm.version>5.8.1</kotest-assertions-core-jvm.version>
+        <mockito-kotlin.version>5.3.1</mockito-kotlin.version>
+        <mockk-jvm.version>1.13.10</mockk-jvm.version>
+        <wiremock.version>3.5.2</wiremock.version>
     </properties>
 
     <repositories>
@@ -243,7 +260,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-csv</artifactId>
-            <version>2.15.3</version>
+            <version>${jackson-dataformat-csv.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -327,13 +344,13 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.4.14</version>
+            <version>${ch.qos.logback.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.13</version>
+            <version>${ch.qos.logback.version}</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.6.1</version>
+                <version>42.7.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -43,9 +43,9 @@
         <jackson-dataformat-csv.version>2.17.0</jackson-dataformat-csv.version>
 
         <!-- Database & Persistence -->
-        <flyway-maven-plugin.version>10.1.0</flyway-maven-plugin.version>
+        <flyway-maven-plugin.version>10.11.0</flyway-maven-plugin.version>
         <ojdbc8.version>19.3.0.0</ojdbc8.version>
-        <shedlock.version>5.6.0</shedlock.version>
+        <shedlock.version>5.13.0</shedlock.version>
         <shedlock-provider-jdbc-template.version>4.33.0
         </shedlock-provider-jdbc-template.version>
         <vault-jdbc.version>1.3.10</vault-jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,12 @@
         <vault-jdbc.version>1.3.10</vault-jdbc.version>
 
         <!-- Kotlin -->
-        <kotlin.version>1.9.0</kotlin.version>
-        <kotlinx-coroutines-core-jvm.version>1.6.4</kotlinx-coroutines-core-jvm.version>
+        <kotlin.version>2.0.0-RC1</kotlin.version>
+        <kotlinx-coroutines-core-jvm.version>1.8.1-Beta</kotlinx-coroutines-core-jvm.version>
 
         <!-- Framework -->
         <ia-felles.version>1.0.0</ia-felles.version>
-        <jetbrainsExposedVersion>0.42.0</jetbrainsExposedVersion>
+        <jetbrainsExposedVersion>0.49.0</jetbrainsExposedVersion>
         <okhttp3.version>5.0.0-alpha.12</okhttp3.version>
         <spring-boot-starter-parent.version>3.1.2</spring-boot-starter-parent.version>
         <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <!-- Authentification / Authorization -->
+        <!-- Authentification / Authorization / Crypto -->
         <altinn-rettigheter-proxy-klient.version>3.1.0</altinn-rettigheter-proxy-klient.version>
-        <nimbus-jose-jwt.version>9.37.2</nimbus-jose-jwt.version>
-        <token-support.version>3.2.0</token-support.version>
+        <bouncy-castle-provider-jdk.version>1.78</bouncy-castle-provider-jdk.version>
+        <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
+        <token-support.version>4.1.4</token-support.version>
 
         <!-- Data manipulation -->
         <json-smart.version>2.5.1</json-smart.version>
@@ -50,8 +51,8 @@
         <vault-jdbc.version>1.3.10</vault-jdbc.version>
 
         <!-- Kotlin -->
-        <kotlin.version>2.0.0-RC1</kotlin.version>
-        <kotlinx-coroutines-core-jvm.version>1.8.1-Beta</kotlinx-coroutines-core-jvm.version>
+        <kotlin.version>1.9.20</kotlin.version>
+        <kotlinx-coroutines-core-jvm.version>1.8.0</kotlinx-coroutines-core-jvm.version>
 
         <!-- Framework -->
         <ia-felles.version>1.0.0</ia-felles.version>
@@ -332,7 +333,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.77</version>
+            <version>${bouncy-castle-provider-jdk.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -366,7 +367,7 @@
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>
                 <configuration>
-                    <jvmTarget>17</jvmTarget>
+                    <jvmTarget>21</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>
@@ -401,8 +402,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/applikasjon/tilgangsstyring/TokenService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/applikasjon/tilgangsstyring/TokenService.kt
@@ -21,12 +21,12 @@ open class TokenService(
     val ISSUER_TOKENX = "tokenx"
 
     fun hentInnloggetJwtToken(): JwtToken {
-        return contextHolder.tokenValidationContext.getJwtToken(ISSUER_TOKENX)
+        return contextHolder.getTokenValidationContext().getJwtToken(ISSUER_TOKENX)
             ?: throw (TilgangskontrollException(String.format("Finner ikke gyldig jwt token")))
     }
 
     fun hentInnloggetBruker(): InnloggetBruker {
-        val context = contextHolder.tokenValidationContext
+        val context = contextHolder.getTokenValidationContext()
         val claims = getClaimsFor(context)
         if (claims.isPresent) {
             log.debug("Claims kommer fra issuer TokenX")

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/RestResponseEntityExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/RestResponseEntityExceptionHandler.kt
@@ -24,7 +24,9 @@ class RestResponseEntityExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(value = [EnhetsregisteretMappingException::class])
     @ResponseBody
     fun handleEnhetsregisteretMappingException(
-        e: RuntimeException, webRequest: WebRequest?
+        e: RuntimeException,
+        @Suppress("UNUSED_PARAMETER")
+        webRequest: WebRequest?
     ): ResponseEntity<Any> {
         return getResponseEntity(
             e, "Kunne ikke lese informasjon om enheten fra Enhetsregisteret", HttpStatus.BAD_REQUEST
@@ -34,7 +36,9 @@ class RestResponseEntityExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(value = [OrgnrEksistererIkkeException::class])
     @ResponseBody
     fun handleOrgnrEksistererIkkeException(
-        e: RuntimeException, webRequest: WebRequest?
+        e: RuntimeException,
+        @Suppress("UNUSED_PARAMETER")
+        webRequest: WebRequest?
     ): ResponseEntity<Any> {
         Companion.logger.warn("Orgnr finnes ikke i Enhetsregisteret", e)
         return getResponseEntity(e, "Orgnr finnes ikke i Enhetsregisteret", HttpStatus.NOT_FOUND)
@@ -43,7 +47,9 @@ class RestResponseEntityExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(value = [EnhetsregisteretIkkeTilgjengeligException::class])
     @ResponseBody
     fun handleEnhetsregisteretIkkeTilgjengeligException(
-        e: RuntimeException, webRequest: WebRequest?
+        e: RuntimeException,
+        @Suppress("UNUSED_PARAMETER")
+        webRequest: WebRequest?
     ): ResponseEntity<Any> {
         Companion.logger.warn(
             "Kunne ikke hente informasjon om enheten fra Enhetsregisteret fordi Enhetsregisteret ikke er tilgjengelig",
@@ -55,7 +61,9 @@ class RestResponseEntityExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(value = [IngenNæringException::class])
     @ResponseBody
     fun handleIngenNæringException(
-        e: RuntimeException, webRequest: WebRequest?
+        e: RuntimeException,
+        @Suppress("UNUSED_PARAMETER")
+        webRequest: WebRequest?
     ): ResponseEntity<Any> {
         Companion.logger.info(
             "Kunne ikke lese informasjon om enheten fra Enhetsregisteret fordi enheten ikke har næring",
@@ -72,7 +80,9 @@ class RestResponseEntityExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(value = [TilgangskontrollException::class])
     @ResponseBody
     fun handleTilgangskontrollException(
-        e: RuntimeException, webRequest: WebRequest?
+        e: RuntimeException,
+        @Suppress("UNUSED_PARAMETER")
+        webRequest: WebRequest?
     ): ResponseEntity<Any> {
         return getResponseEntity(e, "You don't have access to this resource", HttpStatus.FORBIDDEN)
     }
@@ -80,7 +90,9 @@ class RestResponseEntityExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(value = [JwtTokenUnauthorizedException::class, AccessDeniedException::class])
     @ResponseBody
     fun handleUnauthorizedException(
-        e: RuntimeException, webRequest: WebRequest?
+        e: RuntimeException,
+        @Suppress("UNUSED_PARAMETER")
+        webRequest: WebRequest?
     ): ResponseEntity<Any> {
         return getResponseEntity(
             e, "You are not authorized to access this resource", HttpStatus.UNAUTHORIZED
@@ -90,7 +102,9 @@ class RestResponseEntityExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(value = [AltinnException::class])
     @ResponseBody
     fun handleAltinnException(
-        e: RuntimeException, webRequest: WebRequest?
+        e: RuntimeException,
+        @Suppress("UNUSED_PARAMETER")
+        webRequest: WebRequest?
     ): ResponseEntity<Any> {
         Companion.logger.warn("Feil ved Altinn integrasjon", e)
         return getResponseEntity(e, "Internal error", HttpStatus.INTERNAL_SERVER_ERROR)
@@ -99,7 +113,9 @@ class RestResponseEntityExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(value = [Exception::class])
     @ResponseBody
     fun handleGenerellException(
-        e: RuntimeException, webRequest: WebRequest?
+        e: RuntimeException,
+        @Suppress("UNUSED_PARAMETER")
+        webRequest: WebRequest?
     ): ResponseEntity<Any> {
         Companion.logger.error("Uhåndtert feil", e)
         return getResponseEntity(e, "Internal error", HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/altinn/AltinnService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/altinn/AltinnService.kt
@@ -20,7 +20,7 @@ open class AltinnService(
         idToken: JwtToken, fnr: Fnr
     ): List<AltinnOrganisasjon> {
         return klient.hentOrganisasjoner(
-            TokenXToken(idToken.tokenAsString),
+            TokenXToken(idToken.encodedToken),
             Subject(fnr.verdi),
             ServiceCode(serviceCode),
             ServiceEdition(serviceEdition),
@@ -30,7 +30,7 @@ open class AltinnService(
 
     open fun hentVirksomheterDerBrukerHarTilknytning(idToken: JwtToken, fnr: Fnr): List<AltinnOrganisasjon> {
         return klient.hentOrganisasjoner(
-            TokenXToken(idToken.tokenAsString),
+            TokenXToken(idToken.encodedToken),
             Subject(fnr.verdi),
             true
         ).map(::toAltinnOrganisasjon)

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/ImportEksportStatusRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/ImportEksportStatusRepository.kt
@@ -2,10 +2,7 @@ package no.nav.arbeidsgiver.sykefravarsstatistikk.api.infrastruktur.database
 
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.applikasjon.fellesdomene.ÅrstallOgKvartal
 import no.nav.arbeidsgiver.sykefravarsstatistikk.api.infrastruktur.cron.ImportEksportJobb
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.select
-import org.jetbrains.exposed.sql.upsert
+import org.jetbrains.exposed.sql.*
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 
@@ -36,15 +33,16 @@ open class ImportEksportStatusRepository(
 
     private fun hentImportEksportStatus(årstallOgKvartal: ÅrstallOgKvartal): List<ImportEksportStatus> {
         return transaction {
-            select {
-                årstall eq årstallOgKvartal.årstall.toString()
-                kvartal eq årstallOgKvartal.kvartal.toString()
-            }.map {
-                ImportEksportStatus(
-                    årstallOgKvartal = ÅrstallOgKvartal(it[årstall].toInt(), it[kvartal].toInt()),
-                    fullførteJobber = it[fullførteJobber].splittTilListe()
-                )
-            }
+            selectAll()
+                .where {
+                    årstall eq årstallOgKvartal.årstall.toString()
+                    kvartal eq årstallOgKvartal.kvartal.toString()
+                }.map {
+                    ImportEksportStatus(
+                        årstallOgKvartal = ÅrstallOgKvartal(it[årstall].toInt(), it[kvartal].toInt()),
+                        fullførteJobber = it[fullførteJobber].splittTilListe()
+                    )
+                }
         }
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefravarStatistikkVirksomhetGraderingRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefravarStatistikkVirksomhetGraderingRepository.kt
@@ -67,7 +67,7 @@ class SykefravarStatistikkVirksomhetGraderingRepository(
         kvartaler: List<ÅrstallOgKvartal>
     ): List<SykefraværsstatistikkVirksomhetMedGradering> {
         return transaction {
-            slice(
+            select(
                 årstall,
                 kvartal,
                 orgnr,
@@ -81,7 +81,7 @@ class SykefravarStatistikkVirksomhetGraderingRepository(
                 tapteDagsverk.sum(),
                 muligeDagsverk.sum(),
             )
-                .select {
+                .where {
                     (årstall to kvartal) inList kvartaler.map { it.årstall to it.kvartal }
                 }
                 .groupBy(årstall, kvartal, orgnr, næring, næringskode, rectype)
@@ -130,15 +130,16 @@ class SykefravarStatistikkVirksomhetGraderingRepository(
                 (rectype eq Rectype.VIRKSOMHET.kode)
     }
 
+
     private fun hent(where: SqlExpressionBuilder.() -> Op<Boolean>): List<UmaskertSykefraværForEttKvartal> {
         return transaction {
-            slice(
+            select(
                 årstall,
                 kvartal,
                 tapteDagsverkGradertSykemelding.sum(),
                 tapteDagsverk.sum(),
                 antallPersoner.sum(),
-            ).select(where)
+            ).where { where() }
                 .groupBy(årstall, kvartal)
                 .orderBy(årstall to SortOrder.ASC, kvartal to SortOrder.ASC)
                 .map {

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefravarStatistikkVirksomhetRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefravarStatistikkVirksomhetRepository.kt
@@ -26,13 +26,13 @@ class SykefravarStatistikkVirksomhetRepository(
         virksomhet: Virksomhet, kvartaler: List<ÅrstallOgKvartal>
     ): List<UmaskertSykefraværForEttKvartal> {
         return transaction {
-            slice(
+            select(
                 tapteDagsverk.sum(),
                 muligeDagsverk.sum(),
                 antallPersoner.sum(),
                 årstall,
                 kvartal
-            ).select {
+            ).where {
                 orgnr eq virksomhet.orgnr.verdi and (årstall to kvartal inList kvartaler.map { it.årstall to it.kvartal })
             }
                 .groupBy(årstall, kvartal)
@@ -61,7 +61,7 @@ class SykefravarStatistikkVirksomhetRepository(
         varigheter: List<Varighetskategori>
     ): List<UmaskertSykefraværForEttKvartal> {
         return transaction {
-            select {
+            selectAll().where {
                 (orgnr eq organisasjonsnummer.verdi) and
                         (varighet inList varigheter.map { it.kode })
             }.orderBy(
@@ -87,14 +87,14 @@ class SykefravarStatistikkVirksomhetRepository(
         kvartaler: List<ÅrstallOgKvartal>
     ): List<SykefraværsstatistikkVirksomhetUtenVarighet> {
         return transaction {
-            slice(
+            select (
                 årstall,
                 kvartal,
                 orgnr,
                 tapteDagsverk.sum(),
                 muligeDagsverk.sum(),
                 antallPersoner.sum(),
-            ).select {
+            ).where {
                 (årstall to kvartal) inList kvartaler.map { it.årstall to it.kvartal }
             }.groupBy(årstall, kvartal, orgnr)
                 .map {
@@ -127,14 +127,14 @@ class SykefravarStatistikkVirksomhetRepository(
 
     fun hentAlt(organisasjonsnummer: Orgnr): List<SykefraværForEttKvartal> {
         return transaction {
-            slice(
+            select (
                 tapteDagsverk.sum(),
                 muligeDagsverk.sum(),
                 antallPersoner.sum(),
                 årstall,
                 kvartal,
             )
-                .select { orgnr eq organisasjonsnummer.verdi }
+                .where { orgnr eq organisasjonsnummer.verdi }
                 .groupBy(årstall, kvartal)
                 .orderBy(årstall to SortOrder.ASC, kvartal to SortOrder.ASC)
                 .map {

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefraværStatistikkLandRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefraværStatistikkLandRepository.kt
@@ -21,9 +21,10 @@ class SykefraværStatistikkLandRepository(@param:Qualifier("sykefravarsstatistik
 
     fun hentForKvartaler(kvartaler: List<ÅrstallOgKvartal>): List<UmaskertSykefraværForEttKvartal> {
         return transaction {
-            select {
-                årstall to kvartal inList kvartaler.map { it.årstall to it.kvartal }
-            }.orderBy(årstall to SortOrder.ASC, kvartal to SortOrder.ASC)
+            selectAll()
+                .where {
+                    årstall to kvartal inList kvartaler.map { it.årstall to it.kvartal }
+                }.orderBy(årstall to SortOrder.ASC, kvartal to SortOrder.ASC)
                 .map {
                     UmaskertSykefraværForEttKvartal(
                         årstallOgKvartal = ÅrstallOgKvartal(it[årstall], it[kvartal]),

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefraværStatistikkNæringRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefraværStatistikkNæringRepository.kt
@@ -53,13 +53,14 @@ class SykefraværStatistikkNæringRepository(
         kvartaler: List<ÅrstallOgKvartal>
     ): List<SykefraværsstatistikkForNæring> {
         return transaction {
-            select {
-                (årstall to kvartal) inList kvartaler.map { it.årstall to it.kvartal }
-            }.orderBy(
-                årstall to SortOrder.DESC,
-                kvartal to SortOrder.DESC,
-                næring to SortOrder.ASC,
-            ).map {
+            selectAll()
+                .where {
+                    (årstall to kvartal) inList kvartaler.map { it.årstall to it.kvartal }
+                }.orderBy(
+                    årstall to SortOrder.DESC,
+                    kvartal to SortOrder.DESC,
+                    næring to SortOrder.ASC,
+                ).map {
                     SykefraværsstatistikkForNæring(
                         årstall = it[årstall],
                         kvartal = it[kvartal],
@@ -74,16 +75,17 @@ class SykefraværStatistikkNæringRepository(
 
     fun hentKvartalsvisSykefraværprosent(næringa: Næring): List<SykefraværForEttKvartal> {
         return transaction {
-            select {
-                næring eq næringa.tosifferIdentifikator
-            }.orderBy(årstall to SortOrder.ASC, kvartal to SortOrder.ASC).map {
-                SykefraværForEttKvartal(
-                    årstallOgKvartal = ÅrstallOgKvartal(it[årstall], it[kvartal]),
-                    tapteDagsverk = it[tapteDagsverk].toBigDecimal(),
-                    muligeDagsverk = it[muligeDagsverk].toBigDecimal(),
-                    antallPersoner = it[antallPersoner]
-                )
-            }
+            selectAll()
+                .where {
+                    næring eq næringa.tosifferIdentifikator
+                }.orderBy(årstall to SortOrder.ASC, kvartal to SortOrder.ASC).map {
+                    SykefraværForEttKvartal(
+                        årstallOgKvartal = ÅrstallOgKvartal(it[årstall], it[kvartal]),
+                        tapteDagsverk = it[tapteDagsverk].toBigDecimal(),
+                        muligeDagsverk = it[muligeDagsverk].toBigDecimal(),
+                        antallPersoner = it[antallPersoner]
+                    )
+                }
         }
     }
 
@@ -92,17 +94,18 @@ class SykefraværStatistikkNæringRepository(
         kvartaler: List<ÅrstallOgKvartal>
     ): List<UmaskertSykefraværForEttKvartal> {
         return transaction {
-            select {
-                (næring eq næringa.tosifferIdentifikator) and
-                        ((årstall to kvartal) inList kvartaler.map { it.årstall to it.kvartal })
-            }.orderBy(årstall to SortOrder.ASC, kvartal to SortOrder.ASC).map {
-                UmaskertSykefraværForEttKvartal(
-                    årstallOgKvartal = ÅrstallOgKvartal(it[årstall], it[kvartal]),
-                    dagsverkTeller = it[tapteDagsverk].toBigDecimal(),
-                    dagsverkNevner = it[muligeDagsverk].toBigDecimal(),
-                    antallPersoner = it[antallPersoner]
-                )
-            }
+            selectAll()
+                .where {
+                    (næring eq næringa.tosifferIdentifikator) and
+                            ((årstall to kvartal) inList kvartaler.map { it.årstall to it.kvartal })
+                }.orderBy(årstall to SortOrder.ASC, kvartal to SortOrder.ASC).map {
+                    UmaskertSykefraværForEttKvartal(
+                        årstallOgKvartal = ÅrstallOgKvartal(it[årstall], it[kvartal]),
+                        dagsverkTeller = it[tapteDagsverk].toBigDecimal(),
+                        dagsverkNevner = it[muligeDagsverk].toBigDecimal(),
+                        antallPersoner = it[antallPersoner]
+                    )
+                }
         }
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefraværStatistikkNæringskodeMedVarighetRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefraværStatistikkNæringskodeMedVarighetRepository.kt
@@ -78,7 +78,7 @@ class SykefraværStatistikkNæringskodeMedVarighetRepository(
         varigheter: List<Varighetskategori>
     ): List<UmaskertSykefraværForEttKvartal> {
         return transaction {
-            slice(
+            select(
                 årstall,
                 kvartal,
                 næringskode,
@@ -87,7 +87,7 @@ class SykefraværStatistikkNæringskodeMedVarighetRepository(
                 muligeDagsverk.sum(),
                 antallPersoner.sum(),
             )
-                .select {
+                .where {
                     (næringskode like stringLiteral("${næringa.tosifferIdentifikator}%")) and
                             (varighet inList varigheter.map { it.kode!! })
                 }
@@ -109,7 +109,7 @@ class SykefraværStatistikkNæringskodeMedVarighetRepository(
         varigheter: List<Varighetskategori>
     ): List<UmaskertSykefraværForEttKvartal> {
         return transaction {
-            slice(
+            select(
                 årstall,
                 kvartal,
                 næringskode,
@@ -118,7 +118,7 @@ class SykefraværStatistikkNæringskodeMedVarighetRepository(
                 tapteDagsverk.sum(),
                 antallPersoner.sum()
             )
-                .select {
+                .where {
                     (næringskode inList næringskoder.næringskoder) and
                             (varighet inList varigheter.map { it.kode!! })
                 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefraværStatistikkNæringskodeRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefraværStatistikkNæringskodeRepository.kt
@@ -36,14 +36,14 @@ class SykefraværStatistikkNæringskodeRepository(
 
     fun hentKvartalsvisSykefraværprosent(næringskoder: List<Næringskode>): List<SykefraværForEttKvartal> {
         return transaction {
-            slice(
+            select(
                 årstall,
                 kvartal,
                 antallPersoner.sum(),
                 tapteDagsverk.sum(),
                 muligeDagsverk.sum()
             )
-                .select { næringskode inList næringskoder.map { it.femsifferIdentifikator } }
+                .where { næringskode inList næringskoder.map { it.femsifferIdentifikator } }
                 .groupBy(årstall, kvartal)
                 .orderBy(årstall to SortOrder.ASC)
                 .orderBy(kvartal to SortOrder.ASC)
@@ -61,9 +61,10 @@ class SykefraværStatistikkNæringskodeRepository(
 
     fun hentAltForKvartaler(kvartaler: List<ÅrstallOgKvartal>): List<SykefraværsstatistikkForNæringskode> {
         return transaction {
-            select {
-                (årstall to kvartal) inList kvartaler.map { it.årstall to it.kvartal }
-            }
+            selectAll()
+                .where {
+                    (årstall to kvartal) inList kvartaler.map { it.årstall to it.kvartal }
+                }
                 .orderBy(årstall to SortOrder.DESC)
                 .orderBy(kvartal to SortOrder.DESC)
                 .map {
@@ -84,14 +85,14 @@ class SykefraværStatistikkNæringskodeRepository(
         kvartaler: List<ÅrstallOgKvartal>
     ): List<UmaskertSykefraværForEttKvartal> {
         return transaction {
-            slice(
+            select(
                 årstall,
                 kvartal,
                 antallPersoner.sum(),
                 tapteDagsverk.sum(),
                 muligeDagsverk.sum(),
             )
-                .select {
+                .where {
                     (næringskode inList (bransje.bransjeId as BransjeId.Næringskoder).næringskoder) and
                             ((årstall to kvartal) inList kvartaler.map { it.årstall to it.kvartal })
                 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefraværStatistikkSektorRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/SykefraværStatistikkSektorRepository.kt
@@ -35,9 +35,10 @@ class SykefraværStatistikkSektorRepository(
 
     fun hentForKvartaler(kvartaler: List<ÅrstallOgKvartal>): List<SykefraværsstatistikkSektor> {
         return transaction {
-            select {
-                (årstall to kvartal) inList kvartaler.map { it.årstall to it.kvartal }
-            }
+            selectAll()
+                .where {
+                    (årstall to kvartal) inList kvartaler.map { it.årstall to it.kvartal }
+                }
                 .orderBy(årstall to SortOrder.ASC)
                 .orderBy(kvartal to SortOrder.ASC)
                 .map {
@@ -63,9 +64,10 @@ class SykefraværStatistikkSektorRepository(
 
     fun hentKvartalsvisSykefraværprosent(sektor: Sektor): List<SykefraværForEttKvartal> {
         return transaction {
-            select {
-                sektorKode eq sektor.sektorkode
-            }
+            selectAll()
+                .where {
+                    sektorKode eq sektor.sektorkode
+                }
                 .orderBy(årstall to SortOrder.ASC)
                 .orderBy(kvartal to SortOrder.ASC)
                 .map {

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/VirksomhetMetadataRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/database/VirksomhetMetadataRepository.kt
@@ -38,21 +38,22 @@ open class VirksomhetMetadataRepository(
 
     open fun hentVirksomhetMetadata(årstallOgKvartal: ÅrstallOgKvartal): List<VirksomhetMetadata> {
         return transaction {
-            select {
-                (arstall eq årstallOgKvartal.årstall) and (kvartal eq årstallOgKvartal.kvartal)
-            }.map {
-                VirksomhetMetadata(
-                    Orgnr(it[orgnr]),
-                    it[navn],
-                    it[rectype],
-                    Sektor.fraSektorkode(it[sektor])!!,
-                    it[primærnæring],
-                    it[primærnæringskode],
-                    ÅrstallOgKvartal(
-                        it[arstall], it[kvartal]
+            selectAll()
+                .where {
+                    (arstall eq årstallOgKvartal.årstall) and (kvartal eq årstallOgKvartal.kvartal)
+                }.map {
+                    VirksomhetMetadata(
+                        Orgnr(it[orgnr]),
+                        it[navn],
+                        it[rectype],
+                        Sektor.fraSektorkode(it[sektor])!!,
+                        it[primærnæring],
+                        it[primærnæringskode],
+                        ÅrstallOgKvartal(
+                            it[arstall], it[kvartal]
+                        )
                     )
-                )
-            }
+                }
         }
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/datavarehus/DatavarehusAggregertRepositoryV1.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/datavarehus/DatavarehusAggregertRepositoryV1.kt
@@ -26,7 +26,7 @@ class DatavarehusAggregertRepositoryV1(
         årstallOgKvartal: ÅrstallOgKvartal
     ): List<SykefraværsstatistikkVirksomhet> {
         return transaction {
-            slice(
+            select(
                 årstall,
                 kvartal,
                 orgnr,
@@ -35,7 +35,7 @@ class DatavarehusAggregertRepositoryV1(
                 antallPersoner.sum(),
                 tapteDagsverk.sum(),
                 muligeDagsverk.sum(),
-            ).select {
+            ).where {
                 (årstall eq årstallOgKvartal.årstall) and (kvartal eq årstallOgKvartal.kvartal)
             }.groupBy(årstall, kvartal, orgnr, varighet, rectype)
                 .map {
@@ -57,10 +57,10 @@ class DatavarehusAggregertRepositoryV1(
         årstallOgKvartal: ÅrstallOgKvartal
     ): List<SykefraværsstatistikkNæringMedVarighet> {
         return transaction {
-            slice(
+            select(
                 årstall, kvartal, næringskode, varighet,
                 antallPersoner.sum(), tapteDagsverk.sum(), muligeDagsverk.sum()
-            ).select {
+            ).where {
                 (årstall eq årstallOgKvartal.årstall) and
                         (kvartal eq årstallOgKvartal.kvartal) and
                         (varighet neq null) and
@@ -82,8 +82,7 @@ class DatavarehusAggregertRepositoryV1(
 
     fun hentSisteKvartal(): ÅrstallOgKvartal {
         return transaction {
-            slice(årstall, kvartal)
-                .selectAll()
+            select(årstall, kvartal)
                 .orderBy(årstall to SortOrder.DESC, kvartal to SortOrder.DESC)
                 .limit(1).map {
                     ÅrstallOgKvartal(

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/datavarehus/DatavarehusAggregertRepositoryV2.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/datavarehus/DatavarehusAggregertRepositoryV2.kt
@@ -32,7 +32,7 @@ class DatavarehusAggregertRepositoryV2(
 
     fun hentSykefraværsstatistikkVirksomhetMedGradering(årstallOgKvartal: ÅrstallOgKvartal): List<SykefraværsstatistikkVirksomhetMedGradering> {
         return transaction {
-            slice(
+            select(
                 årstall,
                 kvartal,
                 orgnr,
@@ -45,7 +45,7 @@ class DatavarehusAggregertRepositoryV2(
                 antallPersoner.sum(),
                 tapteDagsverk.sum(),
                 muligeDagsverk.sum()
-            ).select {
+            ).where {
                 (årstall eq årstallOgKvartal.årstall) and (kvartal eq årstallOgKvartal.kvartal)
             }.groupBy(årstall, kvartal, orgnr, næring, næringskode, rectype).map {
                 SykefraværsstatistikkVirksomhetMedGradering(
@@ -70,9 +70,9 @@ class DatavarehusAggregertRepositoryV2(
 
     override fun hentVirksomheter(årstallOgKvartal: ÅrstallOgKvartal): List<Orgenhet> {
         return transaction {
-            slice(
+            select(
                 orgnr, rectype, sektor, primærnæringskode, årstall, kvartal
-            ).select {
+            ).where {
                 (årstall eq årstallOgKvartal.årstall) and
                         (kvartal eq årstallOgKvartal.kvartal) and
                         (orgnr.trim().charLength() eq 9) and

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/datavarehus/DatavarehusLandRespository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/datavarehus/DatavarehusLandRespository.kt
@@ -29,8 +29,7 @@ class DatavarehusLandRespository(
 
     fun hentSisteKvartal(): ÅrstallOgKvartal {
         return transaction {
-            slice(årstall, kvartal)
-                .selectAll()
+            select(årstall, kvartal)
                 .orderBy(årstall to SortOrder.DESC, kvartal to SortOrder.DESC)
                 .limit(1).map {
                     ÅrstallOgKvartal(
@@ -43,9 +42,9 @@ class DatavarehusLandRespository(
 
     fun hentFor(årstallOgKvartal: ÅrstallOgKvartal): List<SykefraværsstatistikkLand> {
         return transaction {
-            slice(
+            select(
                 årstall, kvartal, antallPersoner.sum(), tapteDagsverk.sum(), muligeDagsverk.sum()
-            ).select {
+            ).where {
                 (kjønn neq "X") and (næring neq "X") and
                         (årstall eq årstallOgKvartal.årstall) and (kvartal eq årstallOgKvartal.kvartal)
             }.groupBy(
@@ -66,9 +65,9 @@ class DatavarehusLandRespository(
         årstallOgKvartal: ÅrstallOgKvartal,
     ): List<SykefraværsstatistikkSektor> {
         return transaction {
-            slice(
+            select(
                 årstall, kvartal, sektor, antallPersoner.sum(), tapteDagsverk.sum(), muligeDagsverk.sum()
-            ).select {
+            ).where {
                 (kjønn neq "X") and (næring neq "X") and
                         (årstall eq årstallOgKvartal.årstall) and (kvartal eq årstallOgKvartal.kvartal)
             }.groupBy(

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/datavarehus/DatavarehusNæringRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/datavarehus/DatavarehusNæringRepository.kt
@@ -21,9 +21,9 @@ class DatavarehusNæringRepository(
 
     fun hentFor(årstallOgKvartal: ÅrstallOgKvartal): List<SykefraværsstatistikkForNæring> {
         return transaction {
-            slice(
+            select(
                 årstall, kvartal, næring, antallPersoner.sum(), tapteDagsverk.sum(), muligeDagsverk.sum()
-            ).select {
+            ).where {
                 (kjønn neq "X") and (næring neq "X") and
                         (årstall eq årstallOgKvartal.årstall) and (kvartal eq årstallOgKvartal.kvartal)
             }.groupBy(
@@ -43,8 +43,7 @@ class DatavarehusNæringRepository(
 
     fun hentSisteKvartal(): ÅrstallOgKvartal {
         return transaction {
-            slice(årstall, kvartal)
-                .selectAll()
+            select(årstall, kvartal)
                 .orderBy(årstall to SortOrder.DESC, kvartal to SortOrder.DESC)
                 .limit(1).map {
                     ÅrstallOgKvartal(

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/datavarehus/DatavarehusNæringskodeRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/datavarehus/DatavarehusNæringskodeRepository.kt
@@ -20,9 +20,9 @@ class DatavarehusNæringskodeRepository(
 
     fun hentFor(årstallOgKvartal: ÅrstallOgKvartal): List<SykefraværsstatistikkForNæringskode> {
         return transaction {
-            slice(
+            select(
                 årstall, kvartal, næringskode, antallPersoner.sum(), tapteDagsverk.sum(), muligeDagsverk.sum()
-            ).select {
+            ).where {
                 (årstall eq årstallOgKvartal.årstall) and (kvartal eq årstallOgKvartal.kvartal)
             }.groupBy(
                 årstall, kvartal, næringskode
@@ -41,8 +41,7 @@ class DatavarehusNæringskodeRepository(
 
     fun hentSisteKvartal(): ÅrstallOgKvartal {
         return transaction {
-            slice(årstall, kvartal)
-                .selectAll()
+            select(årstall, kvartal)
                 .orderBy(årstall to SortOrder.DESC, kvartal to SortOrder.DESC)
                 .limit(1).map {
                     ÅrstallOgKvartal(

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/datavarehus/DatavarehusPubliseringsdatoerRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/datavarehus/DatavarehusPubliseringsdatoerRepository.kt
@@ -21,11 +21,11 @@ open class DatavarehusPubliseringsdatoerRepository(
 
     open fun hentPubliseringsdatoerFraDvh(): List<Publiseringsdato> {
         return transaction {
-            slice(
+            select(
                 rapportPeriode,
                 offentligDato,
                 oppdatertDato,
-            ).select {
+            ).where {
                 (tabellNavn eq "AGG_FAK_SYKEFRAVAR_DIA") and (periodeType eq "KVARTAL")
             }.orderBy(offentligDato to SortOrder.DESC)
                 .map {

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/tokenx/TokenXClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/infrastruktur/tokenx/TokenXClient.kt
@@ -67,7 +67,13 @@ open class TokenXClient(
             throw httpClientErrorException
         }
         val body: TokenExchangeResponse? = responseEntity.body
-        return JwtToken(body?.access_token)
+        val accessToken: String? = body?.access_token
+
+        if (accessToken == null) {
+            logger.warn("Ingen access token i response fra TokenX")
+            throw TokenXException("Feil ved henting access token fra TokenX")
+        }
+        return JwtToken(accessToken)
     }
 
     @Throws(GeneralException::class, IOException::class)
@@ -110,7 +116,7 @@ open class TokenXClient(
         map.add("audience", altinnRettigheterProxyAudience)
         map.add("client_assertion", assertionToken)
         map.add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
-        map.add("subject_token", token.tokenAsString)
+        map.add("subject_token", token.encodedToken)
         map.add("subject_token_type", "urn:ietf:params:oauth:token-type:jwt")
         map.add("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
         return map

--- a/src/test/resources/application-mvc-test.yaml
+++ b/src/test/resources/application-mvc-test.yaml
@@ -44,7 +44,6 @@ no.nav.security.jwt:
     tokenx:
       discoveryurl: http://localhost:${mock-oauth2-server.port}/tokenx/.well-known/openid-configuration
       accepted_audience: someaudience
-      cookie_name: tokenx-token
 
 ## jwk generert med https://connect2id.com/products/nimbus-jose-jwt/generator
 tokenxclient:


### PR DESCRIPTION
Upgrade Java (17 -> 21) og Kotlin (1.9.0 -> 1.9.20)

Oppdatering av følgende avhengigheter: 
- wiremock (3.3.1 -> 3.5.2), mockk-jvm.version (1.13.8 -> 1.13.10), mockito-kotlin.version (5.1.0 -> 5.3.1)
- jackson-dataformat-csv (2.15.3 -> 2.17.0), logback (1.4.13 -> 1.5.4), micrometer (1.11.2 -> 1.12.5)
- postgresql (42.6.1 -> 42.7.3), flyway-maven-plugin.version (10.1.0 -> 10.11.0), shedlock (5.6.0 -> 5.13.0), jetbrains.exposed (0.42.0 -> 0.49.0)
- token-validation-spring (3.2.0 -> 4.1.4 - krever Java 21 i token-validation-spring-test/mock-oauth2), nimbus-jose-jwt (9.37.2 -> 9.37.3)

Tilpasse kode i repository-klasser etter at noen funksjoner ble deprecated i exposed-core 