### PR TITLE
Bytt baseimage fra navikt/baseimage til google distroless

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - verif-v5-token-validation-support
+      - distroless
     paths-ignore:
       - '**.md'
       - '**/**.md'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM gcr.io/distroless/java21
 ENV APP_NAME=sykefravarsstatistikk-api
 ENV LANG=nb_NO.UTF-8
 ENV LANGUAGE=nb_NO:nb
-ENV LC_ALL=nb:NO.UTF-8
+ENV LC_ALL=nb_NO.UTF-8
 ENV TZ=Europe/Oslo
 ENV JDK_JAVA_OPTIONS="-Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
 #COPY import-vault-secrets.sh /init-scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/navikt/baseimages/temurin:21
-ENV APPD_ENABLED=false
+FROM gcr.io/distroless/java21
+#ENV APPD_ENABLED=false
 ENV APP_NAME=sykefravarsstatistikk-api
-COPY import-vault-secrets.sh /init-scripts
+ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"
+ENV JDK_JAVA_OPTIONS="-Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
+#COPY import-vault-secrets.sh /init-scripts
 COPY /target/sykefravarsstatistikk-api-0.0.1-SNAPSHOT.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM gcr.io/distroless/java21
 #ENV APPD_ENABLED=false
 ENV APP_NAME=sykefravarsstatistikk-api
-ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"
+ENV LANG=nb_NO.UTF-8
+ENV LANGUAGE=nb_NO:nb
+ENV LC_ALL=nb:NO.UTF-8
+ENV TZ=Europe/Oslo
 ENV JDK_JAVA_OPTIONS="-Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
 #COPY import-vault-secrets.sh /init-scripts
 COPY /target/sykefravarsstatistikk-api-0.0.1-SNAPSHOT.jar app.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM eclipse-temurin:21.0.2_13-jdk
+FROM ghcr.io/navikt/baseimages/temurin:21
 
 ENV APP_NAME="sykefravarsstatistikk-api"
 ENV LANG="nb_NO.UTF-8"
 ENV LANGUAGE="nb_NO:nb"
 ENV LC_ALL="nb_NO.UTF-8"
 ENV TZ="Europe/Oslo"
-ENV JDK_JAVA_OPTIONS="-Dfile.encoding=UTF-8 -Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
+ENV JDK_JAVA_OPTIONS="-Dsun.jnu.encoding=UTF-8 -Dfile.encoding=UTF-8 -Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
 
 COPY /target/sykefravarsstatistikk-api-0.0.1-SNAPSHOT.jar app.jar
-#ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM gcr.io/distroless/java21
+FROM ghcr.io/navikt/baseimages/temurin:21
+
 ENV APP_NAME="sykefravarsstatistikk-api"
 ENV LANG="nb_NO.UTF-8"
 ENV LANGUAGE="nb_NO:nb"
 ENV LC_ALL="nb_NO.UTF-8"
 ENV TZ="Europe/Oslo"
 ENV JDK_JAVA_OPTIONS="-Dfile.encoding=UTF-8 -Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
+
 COPY /target/sykefravarsstatistikk-api-0.0.1-SNAPSHOT.jar app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ ENV TZ="Europe/Oslo"
 ENV JDK_JAVA_OPTIONS="-Dfile.encoding=UTF-8 -Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
 
 COPY /target/sykefravarsstatistikk-api-0.0.1-SNAPSHOT.jar app.jar
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+#ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM gcr.io/distroless/java21
-#ENV APPD_ENABLED=false
-ENV APP_NAME=sykefravarsstatistikk-api
-ENV LANG=nb_NO.UTF-8
-ENV LANGUAGE=nb_NO:nb
-ENV LC_ALL=nb_NO.UTF-8
-ENV TZ=Europe/Oslo
+FROM cgr.dev/chainguard/jre:latest
+ENV APP_NAME="sykefravarsstatistikk-api"
+ENV LANG="nb_NO.UTF-8"
+ENV LANGUAGE="nb_NO:nb"
+ENV LC_ALL="nb_NO.UTF-8"
+ENV TZ="Europe/Oslo"
 ENV JDK_JAVA_OPTIONS="-Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
-#COPY import-vault-secrets.sh /init-scripts
 COPY /target/sykefravarsstatistikk-api-0.0.1-SNAPSHOT.jar app.jar
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+CMD ["-jar", "/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ ENV LANGUAGE="nb_NO:nb"
 ENV LC_ALL="nb_NO.UTF-8"
 ENV TZ="Europe/Oslo"
 ENV JDK_JAVA_OPTIONS="-Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
-COPY /target/sykefravarsstatistikk-api-0.0.1-SNAPSHOT.jar app.jar
-CMD ["-jar", "/app.jar"]
+COPY /target/sykefravarsstatistikk-api-0.0.1-SNAPSHOT.jar /app/app.jar
+WORKDIR /app
+CMD ["-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
+FROM busybox:1.36.1-uclibc as busybox
+
 FROM gcr.io/distroless/java21
+
+COPY --from=busybox /bin/sh /bin/sh
+COPY --from=busybox /bin/cat /bin/cat
+COPY --from=busybox /bin/printenv /bin/printenv
 
 ENV APP_NAME="sykefravarsstatistikk-api"
 ENV LANG="nb_NO.UTF-8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,9 @@
-FROM busybox:1.36.1-uclibc as busybox
-
 FROM gcr.io/distroless/java21
 
-COPY --from=busybox /bin/sh /bin/sh
-COPY --from=busybox /bin/cat /bin/cat
-COPY --from=busybox /bin/printenv /bin/printenv
-
 ENV APP_NAME="sykefravarsstatistikk-api"
-ENV LANG="nb_NO.UTF-8"
+ENV LANG="C.UTF-8"
 ENV LANGUAGE="nb_NO:nb"
-ENV LC_ALL="nb_NO.UTF-8"
+ENV LC_ALL="C.UTF-8"
 ENV TZ="Europe/Oslo"
 ENV JDK_JAVA_OPTIONS="-Dsun.jnu.encoding=UTF-8 -Dfile.encoding=UTF-8 -Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM cgr.dev/chainguard/jre:latest
+FROM gcr.io/distroless/java21
 ENV APP_NAME="sykefravarsstatistikk-api"
 ENV LANG="nb_NO.UTF-8"
 ENV LANGUAGE="nb_NO:nb"
 ENV LC_ALL="nb_NO.UTF-8"
 ENV TZ="Europe/Oslo"
-ENV JDK_JAVA_OPTIONS="-Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
-COPY /target/sykefravarsstatistikk-api-0.0.1-SNAPSHOT.jar /app/app.jar
-WORKDIR /app
-CMD ["-jar", "app.jar"]
+ENV JDK_JAVA_OPTIONS="-Dfile.encoding=UTF-8 -Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
+COPY /target/sykefravarsstatistikk-api-0.0.1-SNAPSHOT.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/navikt/baseimages/temurin:21
+FROM gcr.io/distroless/java21
 
 ENV APP_NAME="sykefravarsstatistikk-api"
 ENV LANG="nb_NO.UTF-8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/navikt/baseimages/temurin:21
+FROM eclipse-temurin:21.0.2_13-jdk
 
 ENV APP_NAME="sykefravarsstatistikk-api"
 ENV LANG="nb_NO.UTF-8"

--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -49,6 +49,9 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: dev
+    - name: LC_ALL
+      value: nb_NO.UTF-8
+
   prometheus:
     enabled: true
     path: /sykefravarsstatistikk-api/internal/actuator/prometheus

--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -53,6 +53,10 @@ spec:
     enabled: true
     path: /sykefravarsstatistikk-api/internal/actuator/prometheus
   webproxy: true
+
+  envFrom:
+    - secret: sykefravarsstatistikk-api
+
   vault:
     enabled: true
     paths:

--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -56,9 +56,11 @@ spec:
   vault:
     enabled: true
     paths:
-      - kvPath: /kv/preprod/fss/sykefravarsstatistikk-api/arbeidsgiver
+      - format: env
+        kvPath: /kv/preprod/fss/sykefravarsstatistikk-api/arbeidsgiver
         mountPath: /var/run/secrets/nais.io/vault
-      - kvPath: /apikey/apigw/dev/eksternapp.altinn.serviceowner/sykefravarsstatistikk-api_q1
+      - format: env
+        kvPath: /apikey/apigw/dev/eksternapp.altinn.serviceowner/sykefravarsstatistikk-api_q1
         mountPath: /var/run/secrets/nais.io/altinn
   kafka:
     pool: nav-dev

--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -59,13 +59,7 @@ spec:
 
   vault:
     enabled: true
-    paths:
-      - format: env
-        kvPath: /kv/preprod/fss/sykefravarsstatistikk-api/arbeidsgiver
-        mountPath: /var/run/secrets/nais.io/vault
-      - format: env
-        kvPath: /apikey/apigw/dev/eksternapp.altinn.serviceowner/sykefravarsstatistikk-api_q1
-        mountPath: /var/run/secrets/nais.io/altinn
+
   kafka:
     pool: nav-dev
   resources:

--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -49,8 +49,6 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: dev
-    - name: LC_ALL
-      value: nb_NO.UTF-8
 
   prometheus:
     enabled: true

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/config/ApplikasjonDBConfig.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/config/ApplikasjonDBConfig.kt
@@ -2,6 +2,7 @@ package no.nav.arbeidsgiver.sykefravarsstatistikk.api.config
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import java.nio.charset.Charset
 import no.nav.vault.jdbc.hikaricp.HikariCPVaultUtil
 import no.nav.vault.jdbc.hikaricp.VaultError
 import org.flywaydb.core.Flyway
@@ -74,6 +75,7 @@ open class ApplikasjonDBConfig {
     open fun flywayMigrationStrategy(): FlywayMigrationStrategy {
         return FlywayMigrationStrategy {
             Flyway.configure()
+                .encoding(Charset.forName("UTF-8"))
                 .dataSource(dataSource("admin"))
                 .initSql(String.format("SET ROLE \"%s\"", dbRole("admin")))
                 .load()

--- a/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/config/ApplikasjonDBConfig.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/sykefravarsstatistikk/api/config/ApplikasjonDBConfig.kt
@@ -75,7 +75,7 @@ open class ApplikasjonDBConfig {
     open fun flywayMigrationStrategy(): FlywayMigrationStrategy {
         return FlywayMigrationStrategy {
             Flyway.configure()
-                .encoding(Charset.forName("UTF-8"))
+                .validateMigrationNaming(true)
                 .dataSource(dataSource("admin"))
                 .initSql(String.format("SET ROLE \"%s\"", dbRole("admin")))
                 .load()


### PR DESCRIPTION
For å øke sikkerheten og skrive oss vekk fra å være avhengig av baseimage/vault  bytter vi baseimage til distroless (gcr.io/distroless/java21).

Som en del av dette er hemmeligheter migrert over til google secret manager, og blir der injectetet av NAIS.